### PR TITLE
A bit of cleaning

### DIFF
--- a/database/transaction.go
+++ b/database/transaction.go
@@ -47,7 +47,7 @@ func (tx *Transaction) Writable() bool {
 // It returns an error if the current transaction is already writable.
 func (tx *Transaction) Promote() error {
 	if tx.writable {
-		return errors.New("can't promote a writable transaction")
+		return errors.New("cannot promote a writable transaction")
 	}
 
 	err := tx.Rollback()

--- a/document/encoding/encoding.go
+++ b/document/encoding/encoding.go
@@ -401,7 +401,7 @@ func (e EncodedArray) GetByIndex(i int) (document.Value, error) {
 func decodeValueFromDocument(data []byte, field string) (document.Value, error) {
 	hsize, n := binary.Uvarint(data)
 	if n <= 0 {
-		return document.Value{}, errors.New("can't decode data")
+		return document.Value{}, errors.New("cannot decode data")
 	}
 
 	hdata := data[n : n+int(hsize)]
@@ -410,7 +410,7 @@ func decodeValueFromDocument(data []byte, field string) (document.Value, error) 
 	// skip number of fields
 	_, n = binary.Uvarint(hdata)
 	if n <= 0 {
-		return document.Value{}, errors.New("can't decode data")
+		return document.Value{}, errors.New("cannot decode data")
 	}
 	hdata = hdata[n:]
 

--- a/document/encoding/format.go
+++ b/document/encoding/format.go
@@ -43,7 +43,7 @@ func (h *Header) Decode(data []byte) (int, error) {
 
 	h.Size, n = binary.Uvarint(data)
 	if n <= 0 {
-		return 0, errors.New("can't decode data")
+		return 0, errors.New("cannot decode data")
 	}
 
 	hdata := data[n : n+int(h.Size)]
@@ -51,7 +51,7 @@ func (h *Header) Decode(data []byte) (int, error) {
 
 	h.FieldsCount, n = binary.Uvarint(hdata)
 	if n <= 0 {
-		return 0, errors.New("can't decode data")
+		return 0, errors.New("cannot decode data")
 	}
 	hdata = hdata[n:]
 
@@ -137,7 +137,7 @@ func (f *FieldHeader) Decode(data []byte) (int, error) {
 	// name size
 	f.NameSize, n = binary.Uvarint(data)
 	if n <= 0 {
-		return 0, errors.New("can't decode data")
+		return 0, errors.New("cannot decode data")
 	}
 	data = data[n:]
 	read += n
@@ -150,7 +150,7 @@ func (f *FieldHeader) Decode(data []byte) (int, error) {
 	// type
 	f.Type, n = binary.Uvarint(data)
 	if n <= 0 {
-		return 0, errors.New("can't decode data")
+		return 0, errors.New("cannot decode data")
 	}
 	data = data[n:]
 	read += n
@@ -158,7 +158,7 @@ func (f *FieldHeader) Decode(data []byte) (int, error) {
 	// size
 	f.Size, n = binary.Uvarint(data)
 	if n <= 0 {
-		return 0, errors.New("can't decode data")
+		return 0, errors.New("cannot decode data")
 	}
 	data = data[n:]
 	read += n
@@ -166,7 +166,7 @@ func (f *FieldHeader) Decode(data []byte) (int, error) {
 	// offset
 	f.Offset, n = binary.Uvarint(data)
 	if n <= 0 {
-		return 0, errors.New("can't decode data")
+		return 0, errors.New("cannot decode data")
 	}
 	data = data[n:]
 	read += n

--- a/document/value.go
+++ b/document/value.go
@@ -292,35 +292,35 @@ func (v Value) ConvertTo(t ValueType) (Value, error) {
 	case Int8Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, err
+			return Value{}, fmt.Errorf("cannot convert %q to int8: %w", v.Type, err)
 		}
 		if x > math.MaxInt8 {
-			return Value{}, fmt.Errorf("cannot convert %s to int8: out of range", v.Type)
+			return Value{}, fmt.Errorf("cannot convert %q to int8: out of range", v.Type)
 		}
 
 		return NewInt8Value(int8(x)), nil
 	case Int16Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, err
+			return Value{}, fmt.Errorf("cannot convert %q to int16: %w", v.Type, err)
 		}
 		if x > math.MaxInt16 {
-			return Value{}, fmt.Errorf("cannot convert %s to int16: out of range", v.Type)
+			return Value{}, fmt.Errorf("cannot convert %q to int16: out of range", v.Type)
 		}
 		return NewInt16Value(int16(x)), nil
 	case Int32Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, err
+			return Value{}, fmt.Errorf("cannot convert %q to int32: %w", v.Type, err)
 		}
 		if x > math.MaxInt32 {
-			return Value{}, fmt.Errorf("cannot convert %s to int32: out of range", v.Type)
+			return Value{}, fmt.Errorf("cannot convert %q to int32: out of range", v.Type)
 		}
 		return NewInt32Value(int32(x)), nil
 	case Int64Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, err
+			return Value{}, fmt.Errorf("cannot convert %q to int64: %w", v.Type, err)
 		}
 		return NewInt64Value(x), nil
 	case Float64Value:
@@ -337,7 +337,7 @@ func (v Value) ConvertTo(t ValueType) (Value, error) {
 		return NewDurationValue(x), nil
 	}
 
-	return Value{}, fmt.Errorf("can't convert %q to %q", v.Type, t)
+	return Value{}, fmt.Errorf("cannot convert %q to %s", v.Type, t)
 }
 
 // ConvertToBlob converts a value of type Text or Blob to a slice of bytes.
@@ -352,7 +352,7 @@ func (v Value) ConvertToBlob() ([]byte, error) {
 		return nil, nil
 	}
 
-	return nil, fmt.Errorf("can't convert %q to bytes", v.Type)
+	return nil, fmt.Errorf("cannot convert %q to bytes", v.Type)
 }
 
 // ConvertToText turns a value of type Text or Blob into a string.
@@ -367,7 +367,7 @@ func (v Value) ConvertToText() (string, error) {
 		return "", nil
 	}
 
-	return "", fmt.Errorf("can't convert %q to string", v.Type)
+	return "", fmt.Errorf("cannot convert %q to string", v.Type)
 }
 
 // ConvertToBool returns true if v is truthy, otherwise it returns false.
@@ -406,7 +406,7 @@ func (v Value) ConvertToInt64() (int64, error) {
 		return 0, nil
 	}
 
-	return 0, fmt.Errorf("can't convert %q to int64", v.Type)
+	return 0, fmt.Errorf("type %q incompatible with integer", v.Type)
 }
 
 // ConvertToFloat64 turns any number into a float64.
@@ -436,7 +436,7 @@ func (v Value) ConvertToFloat64() (float64, error) {
 		return 0, nil
 	}
 
-	return 0, fmt.Errorf("can't convert %q to float64", v.Type)
+	return 0, fmt.Errorf("cannot convert %q to float64", v.Type)
 }
 
 // ConvertToDocument returns a document from the value.
@@ -447,7 +447,7 @@ func (v Value) ConvertToDocument() (Document, error) {
 	}
 
 	if v.Type != DocumentValue {
-		return nil, fmt.Errorf("can't convert %q to document", v.Type)
+		return nil, fmt.Errorf("cannot convert %q to document", v.Type)
 	}
 
 	return v.V.(Document), nil
@@ -461,7 +461,7 @@ func (v Value) ConvertToArray() (Array, error) {
 	}
 
 	if v.Type != ArrayValue {
-		return nil, fmt.Errorf("can't convert %q to array", v.Type)
+		return nil, fmt.Errorf("cannot convert %q to array", v.Type)
 	}
 
 	return v.V.(Array), nil
@@ -481,7 +481,7 @@ func (v Value) ConvertToDuration() (time.Duration, error) {
 	if v.Type == TextValue {
 		d, err := time.ParseDuration(string(v.V.([]byte)))
 		if err != nil {
-			return 0, fmt.Errorf("can't convert %q to duration: %v", v.V, err)
+			return 0, fmt.Errorf("cannot convert %q to duration: %v", v.V, err)
 		}
 		return d, nil
 	}
@@ -607,7 +607,7 @@ func calculateValues(a, b Value, operator byte) (res Value, err error) {
 		return calculateIntegers(a, b, operator)
 	}
 
-	err = fmt.Errorf("cannot add value of type %s to value of type %s", a.Type, b.Type)
+	err = fmt.Errorf("cannot add value of type %q to value of type %q", a.Type, b.Type)
 	return
 }
 

--- a/document/value.go
+++ b/document/value.go
@@ -292,35 +292,35 @@ func (v Value) ConvertTo(t ValueType) (Value, error) {
 	case Int8Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, fmt.Errorf("cannot convert %q to int8: %w", v.Type, err)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int8": %w`, v.Type, err)
 		}
 		if x > math.MaxInt8 {
-			return Value{}, fmt.Errorf("cannot convert %q to int8: out of range", v.Type)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int8": out of range`, v.Type)
 		}
 
 		return NewInt8Value(int8(x)), nil
 	case Int16Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, fmt.Errorf("cannot convert %q to int16: %w", v.Type, err)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int16": %w`, v.Type, err)
 		}
 		if x > math.MaxInt16 {
-			return Value{}, fmt.Errorf("cannot convert %q to int16: out of range", v.Type)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int16": out of range`, v.Type)
 		}
 		return NewInt16Value(int16(x)), nil
 	case Int32Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, fmt.Errorf("cannot convert %q to int32: %w", v.Type, err)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int32": %w`, v.Type, err)
 		}
 		if x > math.MaxInt32 {
-			return Value{}, fmt.Errorf("cannot convert %q to int32: out of range", v.Type)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int32": out of range`, v.Type)
 		}
 		return NewInt32Value(int32(x)), nil
 	case Int64Value:
 		x, err := v.ConvertToInt64()
 		if err != nil {
-			return Value{}, fmt.Errorf("cannot convert %q to int64: %w", v.Type, err)
+			return Value{}, fmt.Errorf(`cannot convert %q to "int64": %w`, v.Type, err)
 		}
 		return NewInt64Value(x), nil
 	case Float64Value:
@@ -337,7 +337,7 @@ func (v Value) ConvertTo(t ValueType) (Value, error) {
 		return NewDurationValue(x), nil
 	}
 
-	return Value{}, fmt.Errorf("cannot convert %q to %s", v.Type, t)
+	return Value{}, fmt.Errorf("cannot convert %q to %q", v.Type, t)
 }
 
 // ConvertToBlob converts a value of type Text or Blob to a slice of bytes.
@@ -352,7 +352,7 @@ func (v Value) ConvertToBlob() ([]byte, error) {
 		return nil, nil
 	}
 
-	return nil, fmt.Errorf("cannot convert %q to bytes", v.Type)
+	return nil, fmt.Errorf(`cannot convert %q to "bytes"`, v.Type)
 }
 
 // ConvertToText turns a value of type Text or Blob into a string.
@@ -367,7 +367,7 @@ func (v Value) ConvertToText() (string, error) {
 		return "", nil
 	}
 
-	return "", fmt.Errorf("cannot convert %q to string", v.Type)
+	return "", fmt.Errorf(`cannot convert %q to "string"`, v.Type)
 }
 
 // ConvertToBool returns true if v is truthy, otherwise it returns false.
@@ -406,7 +406,7 @@ func (v Value) ConvertToInt64() (int64, error) {
 		return 0, nil
 	}
 
-	return 0, fmt.Errorf("type %q incompatible with integer", v.Type)
+	return 0, fmt.Errorf(`type %q incompatible with "integer"`, v.Type)
 }
 
 // ConvertToFloat64 turns any number into a float64.
@@ -436,7 +436,7 @@ func (v Value) ConvertToFloat64() (float64, error) {
 		return 0, nil
 	}
 
-	return 0, fmt.Errorf("cannot convert %q to float64", v.Type)
+	return 0, fmt.Errorf(`cannot convert %q to "float64"`, v.Type)
 }
 
 // ConvertToDocument returns a document from the value.
@@ -447,7 +447,7 @@ func (v Value) ConvertToDocument() (Document, error) {
 	}
 
 	if v.Type != DocumentValue {
-		return nil, fmt.Errorf("cannot convert %q to document", v.Type)
+		return nil, fmt.Errorf(`cannot convert %q to "document"`, v.Type)
 	}
 
 	return v.V.(Document), nil
@@ -461,7 +461,7 @@ func (v Value) ConvertToArray() (Array, error) {
 	}
 
 	if v.Type != ArrayValue {
-		return nil, fmt.Errorf("cannot convert %q to array", v.Type)
+		return nil, fmt.Errorf(`cannot convert %q to "array"`, v.Type)
 	}
 
 	return v.V.(Array), nil
@@ -481,7 +481,7 @@ func (v Value) ConvertToDuration() (time.Duration, error) {
 	if v.Type == TextValue {
 		d, err := time.ParseDuration(string(v.V.([]byte)))
 		if err != nil {
-			return 0, fmt.Errorf("cannot convert %q to duration: %v", v.V, err)
+			return 0, fmt.Errorf(`cannot convert %q to "duration": %v`, v.V, err)
 		}
 		return d, nil
 	}
@@ -626,10 +626,10 @@ func convertNumberToInt64(v Value) (int64, error) {
 	case Float64Value:
 		f := v.V.(float64)
 		if f > math.MaxInt64 {
-			return i, errors.New("cannot convert float64 to integer without overflowing")
+			return i, errors.New(`cannot convert "float64" to "integer" without overflowing`)
 		}
 		if math.Trunc(f) != f {
-			return 0, errors.New("cannot convert float64 value to integer without loss of precision")
+			return 0, errors.New(`cannot convert "float64" value to "integer" without loss of precision`)
 		}
 		i = int64(f)
 	case DurationValue:

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -162,13 +162,13 @@ func (p *Parser) parseUnaryExpr() (expr.Expr, error) {
 			return nil, &ParseError{Message: "missing param name"}
 		}
 		if p.orderedParams > 0 {
-			return nil, &ParseError{Message: "can't mix positional arguments with named arguments"}
+			return nil, &ParseError{Message: "cannot mix positional arguments with named arguments"}
 		}
 		p.namedParams++
 		return expr.NamedParam(lit[1:]), nil
 	case scanner.POSITIONALPARAM:
 		if p.namedParams > 0 {
-			return nil, &ParseError{Message: "can't mix positional arguments with named arguments"}
+			return nil, &ParseError{Message: "cannot mix positional arguments with named arguments"}
 		}
 		p.orderedParams++
 		return expr.PositionalParam(p.orderedParams), nil
@@ -258,13 +258,13 @@ func (p *Parser) parseParam() (expr.Expr, error) {
 			return nil, &ParseError{Message: "missing param name"}
 		}
 		if p.orderedParams > 0 {
-			return nil, &ParseError{Message: "can't mix positional arguments with named arguments"}
+			return nil, &ParseError{Message: "cannot mix positional arguments with named arguments"}
 		}
 		p.namedParams++
 		return expr.NamedParam(lit[1:]), nil
 	case scanner.POSITIONALPARAM:
 		if p.namedParams > 0 {
-			return nil, &ParseError{Message: "can't mix positional arguments with named arguments"}
+			return nil, &ParseError{Message: "cannot mix positional arguments with named arguments"}
 		}
 		p.orderedParams++
 		return expr.PositionalParam(p.orderedParams), nil

--- a/sql/query/expr/param.go
+++ b/sql/query/expr/param.go
@@ -56,7 +56,7 @@ func (p PositionalParam) Eval(stack EvalStack) (document.Value, error) {
 func (p PositionalParam) extract(params []Param) (interface{}, error) {
 	idx := int(p - 1)
 	if idx >= len(params) {
-		return nil, fmt.Errorf("can't find param number %d", p)
+		return nil, fmt.Errorf("cannot find param number %d", p)
 	}
 
 	return params[idx].Value, nil


### PR DESCRIPTION
The main purpose of this PR is to improve how errors are returned from `Value.ConvertTo`.

Before, if we tried to convert an incompatible type to an int8 the error was: 
`can't convert "text" to int64`. 
It was a bit obscure but now, the returned error is:
`cannot convert "text" to "int8": type "text" incompatible with integer`

Next to this change, I've made the code more consistent in the errors message:
- before we had a mix of `can't` and `cannot`, now we only have `cannot`
- before the types were sometimes surrounded by double quotes, sometimes not, now they are all surrounded by `""`