### PR TITLE
Better INSERT parsing

### DIFF
--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -203,7 +203,7 @@ func (p *Parser) parseUnaryExpr() (expr.Expr, error) {
 		return expr.DurationValue(d), nil
 	case scanner.LBRACKET:
 		p.Unscan()
-		e, _, err := p.parseDocument()
+		e, err := p.parseDocument()
 		return e, err
 	case scanner.LSBRACKET:
 		p.Unscan()
@@ -310,11 +310,10 @@ func (p *Parser) parseType() document.ValueType {
 }
 
 // parseDocument parses a document
-func (p *Parser) parseDocument() (expr.Expr, bool, error) {
+func (p *Parser) parseDocument() (expr.Expr, error) {
 	// Parse { token.
-	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LBRACKET {
-		p.Unscan()
-		return nil, false, nil
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.LBRACKET {
+		return nil, newParseError(scanner.Tokstr(tok, lit), []string{"{"}, pos)
 	}
 
 	var pairs expr.KVPairs
@@ -338,10 +337,10 @@ func (p *Parser) parseDocument() (expr.Expr, bool, error) {
 
 	// Parse required } token.
 	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.RBRACKET {
-		return nil, true, newParseError(scanner.Tokstr(tok, lit), []string{"}"}, pos)
+		return nil, newParseError(scanner.Tokstr(tok, lit), []string{"}"}, pos)
 	}
 
-	return pairs, true, nil
+	return pairs, nil
 }
 
 // parseKV parses a key-value pair in the form IDENT : Expr.

--- a/sql/parser/insert.go
+++ b/sql/parser/insert.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/genjidb/genji/sql/query"
 	"github.com/genjidb/genji/sql/query/expr"
 	"github.com/genjidb/genji/sql/scanner"
@@ -36,11 +38,22 @@ func (p *Parser) parseInsertStatement() (query.InsertStmt, error) {
 	}
 
 	// Parse VALUES (v1, v2, v3)
-	stmt.Values, err = p.parseValues(valueParser)
+	values, err := p.parseValues(valueParser)
 	if err != nil {
 		return stmt, err
 	}
 
+	// ensure the length of field list is the same as the length of values
+	if withFields {
+		for _, l := range values {
+			el := l.(expr.LiteralExprList)
+			if len(el) != len(stmt.FieldNames) {
+				return stmt, fmt.Errorf("%d values for %d fields", len(el), len(stmt.FieldNames))
+			}
+		}
+	}
+
+	stmt.Values = values
 	return stmt, nil
 }
 

--- a/sql/parser/insert_test.go
+++ b/sql/parser/insert_test.go
@@ -52,7 +52,7 @@ func TestParserInsert(t *testing.T) {
 				Values:    expr.LiteralExprList{expr.NamedParam("foo"), expr.NamedParam("bar")},
 			},
 			false},
-		{"Values / With columns", "INSERT INTO test (a, b) VALUES ('c', 'd', 'e')",
+		{"Values / With fields", "INSERT INTO test (a, b) VALUES ('c', 'd', 'e')",
 			query.InsertStmt{
 				TableName:  "test",
 				FieldNames: []string{"a", "b"},
@@ -69,6 +69,10 @@ func TestParserInsert(t *testing.T) {
 					expr.LiteralExprList{expr.TextValue("e"), expr.TextValue("f")},
 				},
 			}, false},
+		{"Values / With fields / Wrong values", "INSERT INTO test (a, b) VALUES {a: 1}, ('e', 'f')",
+			nil, true},
+		{"Values / Without fields / Wrong values", "INSERT INTO test VALUES {a: 1}, ('e', 'f')",
+			nil, true},
 	}
 
 	for _, test := range tests {

--- a/sql/parser/insert_test.go
+++ b/sql/parser/insert_test.go
@@ -52,14 +52,16 @@ func TestParserInsert(t *testing.T) {
 				Values:    expr.LiteralExprList{expr.NamedParam("foo"), expr.NamedParam("bar")},
 			},
 			false},
-		{"Values / With fields", "INSERT INTO test (a, b) VALUES ('c', 'd', 'e')",
+		{"Values / With fields", "INSERT INTO test (a, b) VALUES ('c', 'd')",
 			query.InsertStmt{
 				TableName:  "test",
 				FieldNames: []string{"a", "b"},
 				Values: expr.LiteralExprList{
-					expr.LiteralExprList{expr.TextValue("c"), expr.TextValue("d"), expr.TextValue("e")},
+					expr.LiteralExprList{expr.TextValue("c"), expr.TextValue("d")},
 				},
 			}, false},
+		{"Values / With too many values", "INSERT INTO test (a, b) VALUES ('c', 'd', 'e')",
+			nil, true},
 		{"Values / Multiple", "INSERT INTO test (a, b) VALUES ('c', 'd'), ('e', 'f')",
 			query.InsertStmt{
 				TableName:  "test",

--- a/sql/query/insert.go
+++ b/sql/query/insert.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document"
@@ -60,10 +59,6 @@ func (stmt InsertStmt) insertDocuments(t *database.Table, stack expr.EvalStack) 
 			return res, err
 		}
 
-		if v.Type != document.DocumentValue {
-			return res, errors.New("values must be a list of documents if field list is empty")
-		}
-
 		d, err := v.ConvertToDocument()
 		if err != nil {
 			return res, err
@@ -94,22 +89,9 @@ func (stmt InsertStmt) insertExprList(t *database.Table, stack expr.EvalStack) (
 
 		// each document must be a list of expressions
 		// (e1, e2, e3, ...) or [e1, e2, e2, ....]
-		if v.Type != document.ArrayValue {
-			return res, errors.New("invalid values")
-		}
-
 		vlist, err := v.ConvertToArray()
 		if err != nil {
 			return res, err
-		}
-
-		lenv, err := document.ArrayLength(vlist)
-		if err != nil {
-			return res, err
-		}
-
-		if len(stmt.FieldNames) != lenv {
-			return res, fmt.Errorf("%d values for %d fields", lenv, len(stmt.FieldNames))
 		}
 
 		// iterate over each value


### PR DESCRIPTION
For INSERT, some checks were done during execution time while they could have been done during parsing time. This PR fixes that for the two following errors:

```sql
// not the same number of elements, len(a, b)!= len(1, 2, 3)
INSERT INTO foo (a, b) VALUES (1, 2, 3)

// bad input:

// list of fields (a, b) with document value {a: 1}
INSERT INTO foo (a, b) VALUES (1, 2), {a: 1}
// expecting documents, got expression list (1, 2)
INSERT INTO foo VALUES (1, 2)
```