### PR TITLE
Safer default document key

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -10,8 +10,6 @@ import (
 // TableConfig holds the configuration of a table
 type TableConfig struct {
 	FieldConstraints []FieldConstraint
-
-	LastKey int64
 }
 
 // ToDocument returns a document from t.
@@ -24,7 +22,6 @@ func (t *TableConfig) ToDocument() document.Document {
 	}
 
 	buf.Add("field_constraints", document.NewArrayValue(vbuf))
-	buf.Add("last_key", document.NewInt64Value(t.LastKey))
 	return buf
 }
 
@@ -46,23 +43,13 @@ func (t *TableConfig) ScanDocument(d document.Document) error {
 
 	t.FieldConstraints = make([]FieldConstraint, l)
 
-	err = ar.Iterate(func(i int, value document.Value) error {
+	return ar.Iterate(func(i int, value document.Value) error {
 		doc, err := value.ConvertToDocument()
 		if err != nil {
 			return err
 		}
 		return t.FieldConstraints[i].ScanDocument(doc)
 	})
-	if err != nil {
-		return err
-	}
-
-	v, err = d.GetByField("last_key")
-	if err != nil {
-		return err
-	}
-	t.LastKey, err = v.ConvertToInt64()
-	return err
 }
 
 // GetPrimaryKey returns the field constraint of the primary key.

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -27,7 +27,6 @@ func TestTableConfigStore(t *testing.T) {
 		FieldConstraints: []FieldConstraint{
 			{Path: []string{"k"}, Type: document.Float64Value, IsPrimaryKey: true},
 		},
-		LastKey: 100,
 	}
 
 	// inserting one should work

--- a/database/database.go
+++ b/database/database.go
@@ -12,12 +12,19 @@ type Database struct {
 	ng engine.Engine
 
 	mu sync.Mutex
+
+	// tableDocIDs holds the latest document ID for a table.
+	// it is cached in this map the first time a table is accessed
+	// and is used by every call to table#Insert to generate the
+	// document key when there is no primary key.
+	tableDocIDs map[string]int64
 }
 
 // New initializes the DB using the given engine.
 func New(ng engine.Engine) (*Database, error) {
 	db := Database{
-		ng: ng,
+		ng:          ng,
+		tableDocIDs: make(map[string]int64),
 	}
 
 	ntx, err := db.ng.Begin(true)

--- a/database/database.go
+++ b/database/database.go
@@ -13,18 +13,18 @@ type Database struct {
 
 	mu sync.Mutex
 
-	// tableDocIDs holds the latest document ID for a table.
+	// tableDocids holds the latest docid for a table.
 	// it is cached in this map the first time a table is accessed
 	// and is used by every call to table#Insert to generate the
-	// document key when there is no primary key.
-	tableDocIDs map[string]int64
+	// docid if the table doesn't have a primary key.
+	tableDocids map[string]int64
 }
 
 // New initializes the DB using the given engine.
 func New(ng engine.Engine) (*Database, error) {
 	db := Database{
 		ng:          ng,
-		tableDocIDs: make(map[string]int64),
+		tableDocids: make(map[string]int64),
 	}
 
 	ntx, err := db.ng.Begin(true)

--- a/database/table.go
+++ b/database/table.go
@@ -117,6 +117,7 @@ func (t *Table) generateKey(d document.Document) ([]byte, error) {
 
 	lastDocID, ok := t.tx.db.tableDocIDs[t.name]
 	if !ok {
+		// if no key was found in the cache, get the largest key in the table
 		it := t.Store.NewIterator(engine.IteratorConfig{Reverse: true})
 		it.Seek(nil)
 		if it.Valid() {

--- a/engine/enginetest/testing.go
+++ b/engine/enginetest/testing.go
@@ -667,6 +667,23 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 		}
 		require.True(t, called)
 	})
+
+	t.Run("With reverse true, one key in the store, and no pivot, should return that key", func(t *testing.T) {
+		st, cleanup := storeBuilder(t, builder)
+		defer cleanup()
+
+		k := []byte{0xFF, 0xFF, 0xFF, 0xFF}
+		err := st.Put(k, []byte{1})
+		require.NoError(t, err)
+
+		it := st.NewIterator(engine.IteratorConfig{Reverse: true})
+		defer it.Close()
+
+		it.Seek(nil)
+
+		require.True(t, it.Valid())
+		require.Equal(t, it.Item().Key(), k)
+	})
 }
 
 // TestStorePut verifies Put behaviour.


### PR DESCRIPTION
This PR changes the way the default document key is generated on tables without primary keys. Previously, multiple transactions executed at the same time could generate the same default keys using the Badger engine, only one transaction would work and the other ones would fail with a `Transaction Conflict`.

This PR makes some major changes:
- it introduces the concept of `docid`, the equivalent of SQLite's `rowid`. Whenever a document is inserted in a table that doesn't contain a primary key, a docid is generated (that's already the current behavior, it's just that it has a new name now). All mentions to "docid" refer specifically to that generated default key, not the user-chosen primary key.
- the next docid is determined by getting the largest docid of the table, then incremented
- the latest docid is cached in the database instance
- the largest docid is no longer stored in the database config
- if the generated docid is greater than the maximum int64, we look for the smallest available docid in the table.

This PR also fixes a bug with the Badger engine iterator that used to not return the right key when reverse is true.
 
Fixes #74 