### PR TITLE
Fix ValueBuffer#Copy method

### DIFF
--- a/document/array.go
+++ b/document/array.go
@@ -106,7 +106,15 @@ func (vb *ValueBuffer) Copy(a Array) error {
 		return err
 	}
 
-	for _, v := range *vb {
+	// if there is nothing to copy
+	// exit early and make sure the array
+	// is not nil but an empty array.
+	if len(*vb) == 0 {
+		*vb = ValueBuffer{}
+		return nil
+	}
+
+	for i, v := range *vb {
 		switch v.Type {
 		case DocumentValue:
 			var buf FieldBuffer
@@ -115,7 +123,10 @@ func (vb *ValueBuffer) Copy(a Array) error {
 				return err
 			}
 
-			*vb = vb.Append(NewDocumentValue(&buf))
+			err = vb.Replace(i, NewDocumentValue(&buf))
+			if err != nil {
+				return err
+			}
 		case ArrayValue:
 			var buf ValueBuffer
 			err = buf.Copy(v.V.(Array))
@@ -123,7 +134,10 @@ func (vb *ValueBuffer) Copy(a Array) error {
 				return err
 			}
 
-			*vb = vb.Append(NewArrayValue(&buf))
+			err = vb.Replace(i, NewArrayValue(&buf))
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/document/array_test.go
+++ b/document/array_test.go
@@ -53,3 +53,26 @@ func TestSortArray(t *testing.T) {
 		})
 	}
 }
+
+func TestValueBufferCopy(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"empty array", `[]`},
+		{"flat", `[1.4,-5,"hello",true]`},
+		{"nested", `[["foo","bar",1],{"a":1},[1,2]]`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var from, to ValueBuffer
+			require.NoError(t, from.UnmarshalJSON([]byte(test.want)))
+			err := to.Copy(from)
+			require.NoError(t, err)
+			got, err := json.Marshal(to)
+			require.NoError(t, err)
+			require.Equal(t, test.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes a bug that made the `ValueBuffer#Copy` method to append nested arrays and nested documents at the end of the array.

Before:
```sql
genji> create table foo (a.1 int primary key);
genji> insert into foo (a) VALUES ([1, 2, [3, 4]]);
genji> select * from foo;
{
  "a": [
    1,
    2,
    [
      3,
      4
    ],
    [
      3,
      4
    ]
  ]
}
```

After:
```sql
genji> create table foo (a.1 int primary key);
genji> insert into foo (a) VALUES ([1, 2, [3, 4]]);
genji> select * from foo;
{
  "a": [
    1,
    2,
    [
      3,
      4
    ]
  ]
}
```

Thank you @tzzed for spotting this bug!