### PR TITLE
Deep copy documents in Replacement node

### DIFF
--- a/sql/planner/replacement.go
+++ b/sql/planner/replacement.go
@@ -66,7 +66,7 @@ func (n *replacementNode) toResult(st document.Stream) (res query.Result, err er
 			}
 
 			docs[i].Reset()
-			err := docs[i].ScanDocument(d)
+			err := docs[i].Copy(d)
 			if err != nil {
 				return err
 			}

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -75,4 +75,24 @@ func TestUpdateStmt(t *testing.T) {
 			require.JSONEq(t, test.expected, buf.String())
 		})
 	}
+
+	t.Run("with arrays", func(t *testing.T) {
+		db, err := genji.Open(":memory:")
+		require.NoError(t, err)
+		defer db.Close()
+
+		res, err := db.Query(`
+			CREATE TABLE foo;
+			INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);
+			UPDATE foo set b = 0;
+			SELECT * FROM foo; 
+		`)
+		require.NoError(t, err)
+		defer res.Close()
+
+		var buf bytes.Buffer
+		err = document.IteratorToJSONArray(&buf, res)
+		require.NoError(t, err)
+		require.JSONEq(t, `[{"a": [1, 0, 0], "b": 0}, {"a": [2, 0], "b": 0}]`, buf.String())
+	})
 }


### PR DESCRIPTION
This PR fixes #107 by doing a deep copy of the document instead of a shallow copy.
Nodes reuse memory between each iteration and the Replacement Node was storing each document in a buffer before writing them into the table, which caused it to write corrupted docs.
