### PR TITLE
Display unquoted field names in result fields

### DIFF
--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -94,6 +94,12 @@ func (p *Parser) parseResultField() (planner.ResultField, error) {
 		return nil, err
 	}
 
+	// FieldSelectors may be quoted, we make sure we name the result field
+	// with the unquoted name instead.
+	if fs, ok := e.(expr.FieldSelector); ok {
+		lit = fs.String()
+	}
+
 	rf := planner.ResultFieldExpr{Expr: e, ExprName: lit}
 
 	// Check if the AS token exists.

--- a/sql/parser/select_test.go
+++ b/sql/parser/select_test.go
@@ -39,6 +39,14 @@ func TestParserSelect(t *testing.T) {
 					"test",
 				)),
 			false},
+		{"WithFieldsWithQuotes", "SELECT `long \"field\"` FROM test",
+			planner.NewTree(
+				planner.NewProjectionNode(
+					planner.NewTableInputNode("test"),
+					[]planner.ResultField{planner.ResultFieldExpr{Expr: expr.FieldSelector([]string{"long \"field\""}), ExprName: "long \"field\""}},
+					"test",
+				)),
+			false},
 		{"WithAlias", "SELECT a AS A, b FROM test",
 			planner.NewTree(
 				planner.NewProjectionNode(


### PR DESCRIPTION
This PR fixes #64 by adding a special case in the parser for FieldSelectors. It makes sure we are always displaying the unquoted version of these fields instead of the raw version entered by the user.