### PR TITLE
Replace TableConfig by TableInfo

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -12,8 +12,6 @@ import (
 	"github.com/genjidb/genji/index"
 )
 
-// TODO: check if adding Constraints type worth it.
-
 // FieldConstraint describes constraints on a particular field.
 type FieldConstraint struct {
 	Path         document.ValuePath

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -23,24 +23,25 @@ func TestTableInfoStore(t *testing.T) {
 
 	tcs := tableInfoStore{st}
 
-	cfg := TableConfig{
+	info := &TableInfo{
 		FieldConstraints: []FieldConstraint{
 			{Path: []string{"k"}, Type: document.Float64Value, IsPrimaryKey: true},
 		},
 	}
 
 	// Inserting one tableInfo should work.
-	ti, err := tcs.Insert("foo1", cfg)
+	sid, err := tcs.Insert("foo1", info)
 	require.NoError(t, err)
+	require.NotNil(t, sid)
 
 	// Inserting an existing tableInfo should not work.
-	_, err = tcs.Insert("foo1", cfg)
+	_, err = tcs.Insert("foo1", info)
 	require.Equal(t, err, ErrTableAlreadyExists)
 
 	// Listing all tables should return their name
 	// lexicographically ordered.
-	_, _ = tcs.Insert("foo3", cfg)
-	_, _ = tcs.Insert("foo2", cfg)
+	_, _ = tcs.Insert("foo3", info)
+	_, _ = tcs.Insert("foo2", info)
 	lt, err := tcs.ListTables()
 	require.NoError(t, err)
 	require.Equal(t, []string{"foo1", "foo2", "foo3"}, lt)
@@ -48,22 +49,11 @@ func TestTableInfoStore(t *testing.T) {
 	// Getting an existing tableInfo should work.
 	received, err := tcs.Get("foo1")
 	require.NoError(t, err)
-	require.Equal(t, ti, received)
+	require.NotNil(t, received.storeID)
 
 	// Getting a non-existing tableInfo should not work.
 	_, err = tcs.Get("unknown")
 	require.Equal(t, ErrTableNotFound, err)
-
-	// Updating the config table.
-	fc := FieldConstraint{Path: []string{"j"}, Type: document.TextValue, IsNotNull: true}
-	cfg.FieldConstraints = append(cfg.FieldConstraints, fc)
-	err = tcs.Replace("foo1", &cfg)
-	require.NoError(t, err)
-
-	received, err = tcs.Get("foo1")
-	require.NoError(t, err)
-	require.Equal(t, ti.storeID, received.storeID)
-	require.Equal(t, cfg.FieldConstraints, received.FieldConstraints)
 
 	// Deleting an existing tableInfo should work.
 	err = tcs.Delete("foo1")

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -63,7 +63,7 @@ func TestTableInfoStore(t *testing.T) {
 	received, err = tcs.Get("foo1")
 	require.NoError(t, err)
 	require.Equal(t, ti.storeID, received.storeID)
-	require.Equal(t, cfg, *received.cfg)
+	require.Equal(t, cfg.FieldConstraints, received.FieldConstraints)
 
 	// Deleting an existing tableInfo should work.
 	err = tcs.Delete("foo1")

--- a/database/table.go
+++ b/database/table.go
@@ -90,7 +90,7 @@ func (t *Table) GetDocument(key []byte) (document.Document, error) {
 	return &d, err
 }
 
-// generate a key for d based on the table constraints.
+// generate a key for d based on the table configuration.
 // if the table has a primary key, it extracts the field from
 // the document, converts it to the targeted type and returns
 // its encoded version.

--- a/database/table.go
+++ b/database/table.go
@@ -27,7 +27,8 @@ func (t *Table) Config() (*TableConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ti.cfg, nil
+
+	return &TableConfig{FieldConstraints: ti.FieldConstraints}, nil
 }
 
 type encodedDocumentWithKey struct {
@@ -101,7 +102,7 @@ func (t *Table) generateKey(d document.Document) ([]byte, error) {
 		return nil, err
 	}
 
-	cfg := ti.cfg
+	cfg := &TableConfig{FieldConstraints: ti.FieldConstraints}
 
 	if pk := cfg.GetPrimaryKey(); pk != nil {
 		v, err := pk.Path.GetValue(d)

--- a/database/table.go
+++ b/database/table.go
@@ -102,9 +102,7 @@ func (t *Table) generateKey(d document.Document) ([]byte, error) {
 		return nil, err
 	}
 
-	info := &TableInfo{FieldConstraints: ti.FieldConstraints}
-
-	if pk := info.GetPrimaryKey(); pk != nil {
+	if pk := ti.GetPrimaryKey(); pk != nil {
 		v, err := pk.Path.GetValue(d)
 		if err == document.ErrFieldNotFound {
 			return nil, fmt.Errorf("missing primary key at path %q", pk.Path)

--- a/database/table_test.go
+++ b/database/table_test.go
@@ -151,7 +151,7 @@ func TestTableInsert(t *testing.T) {
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
 
-			_ = tx.CreateTable("test", &database.TableConfig{})
+			_ = tx.CreateTable("test", &database.TableInfo{})
 
 			tb, err := tx.GetTable("test")
 			require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableConfig{
+		err := tx.CreateTable("test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{Path: []string{"foo", "a", "1"}, Type: document.Int32Value, IsPrimaryKey: true},
 			},
@@ -260,7 +260,7 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableConfig{
+		err := tx.CreateTable("test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{Path: []string{"foo"}, Type: document.ArrayValue},
 				{Path: []string{"foo", "0"}, Type: document.Int32Value},
@@ -290,7 +290,7 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableConfig{
+		err := tx.CreateTable("test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{Path: []string{"foo"}, Type: document.Int32Value, IsPrimaryKey: true},
 			},
@@ -367,7 +367,7 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableConfig{
+		err := tx.CreateTable("test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{[]string{"foo"}, document.Int32Value, false, false},
 				{[]string{"bar"}, document.Int8Value, false, false},
@@ -405,7 +405,7 @@ func TestTableInsert(t *testing.T) {
 		defer cleanup()
 
 		// no enforced type, not null
-		err := tx.CreateTable("test1", &database.TableConfig{
+		err := tx.CreateTable("test1", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{[]string{"foo"}, 0, false, true},
 			},
@@ -415,7 +415,7 @@ func TestTableInsert(t *testing.T) {
 		require.NoError(t, err)
 
 		// enforced type, not null
-		err = tx.CreateTable("test2", &database.TableConfig{
+		err = tx.CreateTable("test2", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{[]string{"foo"}, document.Int32Value, false, true},
 			},
@@ -459,7 +459,7 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test1", &database.TableConfig{
+		err := tx.CreateTable("test1", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{[]string{"foo", "1"}, 0, false, true},
 			},

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -66,16 +66,16 @@ func (tx *Transaction) Promote() error {
 
 // CreateTable creates a table with the given name.
 // If it already exists, returns ErrTableAlreadyExists.
-func (tx Transaction) CreateTable(name string, cfg *TableConfig) error {
-	if cfg == nil {
-		cfg = new(TableConfig)
+func (tx Transaction) CreateTable(name string, info *TableInfo) error {
+	if info == nil {
+		info = new(TableInfo)
 	}
-	ti, err := tx.tableInfoStore.Insert(name, *cfg)
+	sid, err := tx.tableInfoStore.Insert(name, info)
 	if err != nil {
 		return err
 	}
 
-	err = tx.Tx.CreateStore(ti.storeID[:])
+	err = tx.Tx.CreateStore(sid)
 	if err != nil {
 		return fmt.Errorf("failed to create table %q: %w", name, err)
 	}

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -46,8 +46,8 @@ func (p *Parser) parseCreateTableStatement() (query.CreateTableStmt, error) {
 		return stmt, err
 	}
 
-	// parse table constraints
-	err = p.parseConstraints(&stmt.Info)
+	// parse fields constraints
+	err = p.parseFieldsConstraints(&stmt.Info)
 	if err != nil {
 		return stmt, err
 	}
@@ -75,7 +75,7 @@ func (p *Parser) parseIfNotExists() (bool, error) {
 	return true, nil
 }
 
-func (p *Parser) parseConstraints(info *database.TableInfo) error {
+func (p *Parser) parseFieldsConstraints(info *database.TableInfo) error {
 	// Parse ( token.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LPAREN {
 		p.Unscan()

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -46,8 +46,8 @@ func (p *Parser) parseCreateTableStatement() (query.CreateTableStmt, error) {
 		return stmt, err
 	}
 
-	// parse fields constraints
-	err = p.parseFieldsConstraints(&stmt.Info)
+	// parse field constraints
+	err = p.parseFieldConstraints(&stmt.Info)
 	if err != nil {
 		return stmt, err
 	}
@@ -75,7 +75,7 @@ func (p *Parser) parseIfNotExists() (bool, error) {
 	return true, nil
 }
 
-func (p *Parser) parseFieldsConstraints(info *database.TableInfo) error {
+func (p *Parser) parseFieldConstraints(info *database.TableInfo) error {
 	// Parse ( token.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LPAREN {
 		p.Unscan()

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -46,8 +46,8 @@ func (p *Parser) parseCreateTableStatement() (query.CreateTableStmt, error) {
 		return stmt, err
 	}
 
-	// parse table config
-	err = p.parseTableConfig(&stmt.Config)
+	// parse table constraints
+	err = p.parseConstraints(&stmt.Info)
 	if err != nil {
 		return stmt, err
 	}
@@ -75,7 +75,7 @@ func (p *Parser) parseIfNotExists() (bool, error) {
 	return true, nil
 }
 
-func (p *Parser) parseTableConfig(cfg *database.TableConfig) error {
+func (p *Parser) parseConstraints(info *database.TableInfo) error {
 	// Parse ( token.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LPAREN {
 		p.Unscan()
@@ -101,7 +101,7 @@ func (p *Parser) parseTableConfig(cfg *database.TableConfig) error {
 			return err
 		}
 
-		cfg.FieldConstraints = append(cfg.FieldConstraints, fc)
+		info.FieldConstraints = append(info.FieldConstraints, fc)
 
 		if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.COMMA {
 			p.Unscan()
@@ -116,7 +116,7 @@ func (p *Parser) parseTableConfig(cfg *database.TableConfig) error {
 
 	// ensure only one primary key
 	var pkCount int
-	for _, fc := range cfg.FieldConstraints {
+	for _, fc := range info.FieldConstraints {
 		if fc.IsPrimaryKey {
 			pkCount++
 		}

--- a/sql/parser/create_test.go
+++ b/sql/parser/create_test.go
@@ -21,7 +21,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With primary key", "CREATE TABLE test(foo INT PRIMARY KEY)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, Type: document.Int64Value, IsPrimaryKey: true},
 					},
@@ -32,7 +32,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With type", "CREATE TABLE test(foo INT)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, Type: document.Int64Value},
 					},
@@ -41,7 +41,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With not null", "CREATE TABLE test(foo NOT NULL)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, IsNotNull: true},
 					},
@@ -52,7 +52,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With type and not null", "CREATE TABLE test(foo INT NOT NULL)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, Type: document.Int64Value, IsNotNull: true},
 					},
@@ -61,7 +61,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With not null and primary key", "CREATE TABLE test(foo INT NOT NULL PRIMARY KEY)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, Type: document.Int64Value, IsPrimaryKey: true, IsNotNull: true},
 					},
@@ -70,7 +70,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With primary key and not null", "CREATE TABLE test(foo INT PRIMARY KEY NOT NULL)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, Type: document.Int64Value, IsPrimaryKey: true, IsNotNull: true},
 					},
@@ -79,7 +79,7 @@ func TestParserCreateTable(t *testing.T) {
 		{"With multiple constraints", "CREATE TABLE test(foo INT PRIMARY KEY, bar INT16 NOT NULL, baz.4.1.bat STRING)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"foo"}, Type: document.Int64Value, IsPrimaryKey: true},
 						{Path: []string{"bar"}, Type: document.Int16Value, IsNotNull: true},
@@ -93,7 +93,7 @@ func TestParserCreateTable(t *testing.T) {
 			"CREATE TABLE test(i8 int8, i16 int16, i32 int32, i64 int64, f64 float64, b bool)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"i8"}, Type: document.Int8Value},
 						{Path: []string{"i16"}, Type: document.Int16Value},
@@ -108,7 +108,7 @@ func TestParserCreateTable(t *testing.T) {
 			"CREATE TABLE test(i int, ig integer, n numeric, du duration, b blob, byt bytes, t text, s string, a array, d document)",
 			query.CreateTableStmt{
 				TableName: "test",
-				Config: database.TableConfig{
+				Info: database.TableInfo{
 					FieldConstraints: []database.FieldConstraint{
 						{Path: []string{"i"}, Type: document.Int64Value},
 						{Path: []string{"ig"}, Type: document.Int64Value},

--- a/sql/query/create.go
+++ b/sql/query/create.go
@@ -12,7 +12,7 @@ import (
 type CreateTableStmt struct {
 	TableName   string
 	IfNotExists bool
-	Config      database.TableConfig
+	Info        database.TableInfo
 }
 
 // IsReadOnly always returns false. It implements the Statement interface.
@@ -29,7 +29,7 @@ func (stmt CreateTableStmt) Run(tx *database.Transaction, args []expr.Param) (Re
 		return res, errors.New("missing table name")
 	}
 
-	err := tx.CreateTable(stmt.TableName, &stmt.Config)
+	err := tx.CreateTable(stmt.TableName, &stmt.Info)
 	if stmt.IfNotExists && err == database.ErrTableAlreadyExists {
 		err = nil
 	}

--- a/sql/query/create_test.go
+++ b/sql/query/create_test.go
@@ -54,21 +54,19 @@ func TestCreateTable(t *testing.T) {
 			require.NoError(t, err)
 
 			err = db.ViewTable("test", func(_ *genji.Tx, tb *database.Table) error {
-				cfg, err := tb.Config()
+				info, err := tb.Info()
 				if err != nil {
 					return err
 				}
 
-				require.Equal(t, &database.TableConfig{
-					FieldConstraints: []database.FieldConstraint{
-						{Path: []string{"i8"}, Type: document.Int8Value},
-						{Path: []string{"i16"}, Type: document.Int16Value},
-						{Path: []string{"i32"}, Type: document.Int32Value},
-						{Path: []string{"i64"}, Type: document.Int64Value},
-						{Path: []string{"f64"}, Type: document.Float64Value},
-						{Path: []string{"b"}, Type: document.BoolValue},
-					},
-				}, cfg)
+				require.Equal(t, []database.FieldConstraint{
+					{Path: []string{"i8"}, Type: document.Int8Value},
+					{Path: []string{"i16"}, Type: document.Int16Value},
+					{Path: []string{"i32"}, Type: document.Int32Value},
+					{Path: []string{"i64"}, Type: document.Int64Value},
+					{Path: []string{"f64"}, Type: document.Float64Value},
+					{Path: []string{"b"}, Type: document.BoolValue},
+				}, info.FieldConstraints)
 				return nil
 			})
 			require.NoError(t, err)
@@ -85,25 +83,23 @@ func TestCreateTable(t *testing.T) {
 			require.NoError(t, err)
 
 			err = db.ViewTable("test1", func(_ *genji.Tx, tb *database.Table) error {
-				cfg, err := tb.Config()
+				info, err := tb.Info()
 				if err != nil {
 					return err
 				}
 
-				require.Equal(t, &database.TableConfig{
-					FieldConstraints: []database.FieldConstraint{
-						{Path: []string{"foo", "bar", "1", "hello"}, Type: document.BlobValue, IsPrimaryKey: true},
-						{Path: []string{"foo", "a", "1", "2"}, Type: document.TextValue, IsNotNull: true},
-						{Path: []string{"bar", "4", "0", "bat"}, Type: document.Int64Value},
-						{Path: []string{"ig"}, Type: document.Int64Value},
-						{Path: []string{"n"}, Type: document.Float64Value},
-						{Path: []string{"du"}, Type: document.DurationValue},
-						{Path: []string{"b"}, Type: document.BlobValue},
-						{Path: []string{"t"}, Type: document.TextValue},
-						{Path: []string{"a"}, Type: document.ArrayValue},
-						{Path: []string{"d"}, Type: document.DocumentValue},
-					},
-				}, cfg)
+				require.Equal(t, []database.FieldConstraint{
+					{Path: []string{"foo", "bar", "1", "hello"}, Type: document.BlobValue, IsPrimaryKey: true},
+					{Path: []string{"foo", "a", "1", "2"}, Type: document.TextValue, IsNotNull: true},
+					{Path: []string{"bar", "4", "0", "bat"}, Type: document.Int64Value},
+					{Path: []string{"ig"}, Type: document.Int64Value},
+					{Path: []string{"n"}, Type: document.Float64Value},
+					{Path: []string{"du"}, Type: document.DurationValue},
+					{Path: []string{"b"}, Type: document.BlobValue},
+					{Path: []string{"t"}, Type: document.TextValue},
+					{Path: []string{"a"}, Type: document.ArrayValue},
+					{Path: []string{"d"}, Type: document.DocumentValue},
+				}, info.FieldConstraints)
 				return nil
 			})
 			require.NoError(t, err)

--- a/sql/query/expr/expr.go
+++ b/sql/query/expr/expr.go
@@ -44,7 +44,7 @@ type EvalStack struct {
 	Tx       *database.Transaction
 	Document document.Document
 	Params   []Param
-	Cfg      *database.TableConfig
+	Info     *database.TableInfo
 }
 
 type simpleOperator struct {

--- a/sql/query/expr/expr_test.go
+++ b/sql/query/expr/expr_test.go
@@ -26,15 +26,15 @@ var stackWithDoc = expr.EvalStack{
 	Document: doc,
 }
 
-var fakeTableConfig = &database.TableConfig{
+var fakeTableInfo = &database.TableInfo{
 	FieldConstraints: []database.FieldConstraint{
 		{Path: []string{"c", "0"}, IsPrimaryKey: true},
 		{Path: []string{"c", "1"}},
 	},
 }
-var stackWithDocAndConfig = expr.EvalStack{
+var stackWithDocAndInfo = expr.EvalStack{
 	Document: doc,
-	Cfg:      fakeTableConfig,
+	Info:     fakeTableInfo,
 }
 
 var nullLitteral = document.NewNullValue()

--- a/sql/query/expr/function.go
+++ b/sql/query/expr/function.go
@@ -33,11 +33,11 @@ type PKFunc struct{}
 
 // Eval returns the primary key of the current document.
 func (k PKFunc) Eval(ctx EvalStack) (document.Value, error) {
-	if ctx.Cfg == nil {
+	if ctx.Info == nil {
 		return document.Value{}, errors.New("no table specified")
 	}
 
-	pk := ctx.Cfg.GetPrimaryKey()
+	pk := ctx.Info.GetPrimaryKey()
 	if pk != nil {
 		return pk.Path.GetValue(ctx.Document)
 	}

--- a/sql/query/expr/function_test.go
+++ b/sql/query/expr/function_test.go
@@ -16,7 +16,7 @@ func TestPkExpr(t *testing.T) {
 	}{
 		{"empty stack", expr.EvalStack{}, nullLitteral, true},
 		{"stack with doc", stackWithDoc, nullLitteral, true},
-		{"stack with doc and config", stackWithDocAndConfig, document.NewIntValue(1), false},
+		{"stack with doc and info", stackWithDocAndInfo, document.NewIntValue(1), false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
As suggested in https://github.com/genjidb/genji/pull/110#discussion_r451303589, this PR removes the `TableConfig` type and replaces it by the `TableInfo` one.

`TableInfo` now holds _all_ informations regarding a table.