### PR TITLE
Ignore Input shell with whitespaces only or no input

### DIFF
--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -185,6 +185,7 @@ func (sh *Shell) execute(in string) {
 }
 
 func (sh *Shell) executeInput(in string) error {
+	in = strings.TrimSpace(in)
 	switch {
 	// if it starts with a "." it's a command
 	// it must not be in the middle of a multi line query though
@@ -198,6 +199,9 @@ func (sh *Shell) executeInput(in string) error {
 		err := sh.runQuery(sh.query)
 		sh.query = ""
 		return err
+	// If the input is empty we ignore it
+	case in == "":
+		return nil
 	// If we reach this case, it means the user is in the middle of a
 	// multi line query. We change the prompt and set the multiLine var to true.
 	default:


### PR DESCRIPTION
This PR fixes #106 by adding `TrimSpace` of input.
The command is ignored if the input is empty.