### PR TITLE
Allow dot notation for update set.

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -102,7 +102,7 @@ func (fb *FieldBuffer) setFieldValue(field string, reqValue Value) error {
 }
 
 // setValueAtPath deep replaces or creates a field
-// through the value path to get the value and create or replace it.
+// using the value path
 func (fb *FieldBuffer) setValueAtPath(v Value, p ValuePath, newValue Value) (Value, error) {
 
 	switch v.Type {
@@ -170,13 +170,7 @@ func (fb *FieldBuffer) Set(path ValuePath, reqValue Value) error {
 
 	for i, field := range fb.fields {
 		if path[0] == field.Field {
-			var buf FieldBuffer
-			err := buf.Copy(fb)
-			if err != nil {
-				return err
-			}
-
-			v, err := buf.setValueAtPath(field.Value, path[1:], reqValue)
+			v, err := fb.setValueAtPath(field.Value, path[1:], reqValue)
 			if err != nil {
 				return err
 			}
@@ -185,7 +179,7 @@ func (fb *FieldBuffer) Set(path ValuePath, reqValue Value) error {
 		}
 	}
 
-	//return Err if the request is like foo.1.2.etc where foo doesn't exist
+	// return an error if the first element of the path is not found
 	return ErrFieldNotFound
 }
 

--- a/document/document.go
+++ b/document/document.go
@@ -108,7 +108,7 @@ func (fb *FieldBuffer) setValueAtPath(v Value, p ValuePath, newValue Value) (Val
 	switch v.Type {
 	case DocumentValue:
 		var buf FieldBuffer
-		err := buf.Copy(v.V.(Document))
+		err := buf.ScanDocument(v.V.(Document))
 		if err != nil {
 			return v, err
 		}
@@ -132,7 +132,7 @@ func (fb *FieldBuffer) setValueAtPath(v Value, p ValuePath, newValue Value) (Val
 		return NewDocumentValue(&buf), err
 	case ArrayValue:
 		var vb ValueBuffer
-		err := vb.Copy(v.V.(Array))
+		err := vb.ScanArray(v.V.(Array))
 		if err != nil {
 			return v, err
 		}

--- a/document/document_test.go
+++ b/document/document_test.go
@@ -85,7 +85,6 @@ func TestFieldBuffer(t *testing.T) {
 		err = buf.Copy(d)
 		require.NoError(t, err)
 
-
 		var fb document.FieldBuffer
 		d, err = document.NewFromJSON([]byte(`{"phone":{"type": "cell", "number":"111-222-333"}}`))
 		require.NoError(t, err)
@@ -98,10 +97,10 @@ func TestFieldBuffer(t *testing.T) {
 		vb = vb.Append(document.NewIntegerValue(0))
 
 		tests := []struct {
-			name     string
-			p        document.ValuePath
-			v 		document.Value
-			want    string
+			name string
+			p    document.ValuePath
+			v    document.Value
+			want string
 		}{
 			{"Set replace field textValue",
 				document.NewValuePath("friends.0.name"),
@@ -140,7 +139,6 @@ func TestFieldBuffer(t *testing.T) {
 				document.NewTextValue("foo@example.com"),
 				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [[1, 0, 0], 99, 0]}], "contact": {"phone": {"type": "fix", "number": "111-222-333"}, "email": "foo@example.com"}}`,
 			},
-
 		}
 
 		for _, test := range tests {

--- a/document/document_test.go
+++ b/document/document_test.go
@@ -1,6 +1,7 @@
 package document_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -78,20 +79,80 @@ func TestFieldBuffer(t *testing.T) {
 	})
 
 	t.Run("Set", func(t *testing.T) {
+		d, err := document.NewFromJSON([]byte(`{"friends": [{"name": "Bar","address": {"city": "Paris","zipcode": "75001"}}]}`))
+		require.NoError(t, err)
 		var buf document.FieldBuffer
-		buf.Add("a", document.NewIntegerValue(10))
-		buf.Add("b", document.NewTextValue("hello"))
-
-		buf.Set("a", document.NewDoubleValue(11))
-		v, err := buf.GetByField("a")
+		err = buf.Copy(d)
 		require.NoError(t, err)
-		require.Equal(t, document.NewDoubleValue(11), v)
 
-		buf.Set("c", document.NewIntegerValue(12))
-		require.Equal(t, 3, buf.Len())
-		v, err = buf.GetByField("c")
+
+		var fb document.FieldBuffer
+		d, err = document.NewFromJSON([]byte(`{"phone":{"type": "cell", "number":"111-222-333"}}`))
 		require.NoError(t, err)
-		require.Equal(t, document.NewIntegerValue(12), v)
+		err = fb.Copy(d)
+		require.NoError(t, err)
+
+		var vb document.ValueBuffer
+		vb = vb.Append(document.NewIntegerValue(1))
+		vb = vb.Append(document.NewIntegerValue(0))
+		vb = vb.Append(document.NewIntegerValue(0))
+
+		tests := []struct {
+			name     string
+			p        document.ValuePath
+			v 		document.Value
+			want    string
+		}{
+			{"Set replace field textValue",
+				document.NewValuePath("friends.0.name"),
+				document.NewTextValue("Baz"),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}}]}`,
+			},
+			{"Set array",
+				document.NewValuePath("friends.0.a"),
+				document.NewArrayValue(&vb),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [1, 0, 0]}]}`,
+			},
+			{"Nested array",
+				document.NewValuePath("friends.0.a.0"),
+				document.NewArrayValue(&vb),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [[1, 0, 0], 0, 0]}]}`,
+			},
+			{"Set at index",
+				document.NewValuePath("friends.0.a.1"),
+				document.NewIntegerValue(99),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [[1, 0, 0], 99, 0]}]}`,
+			},
+			{
+				"Set Document",
+				document.NewValuePath("contact"),
+				document.NewDocumentValue(&fb),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [[1, 0, 0], 99, 0]}], "contact": {"phone": {"type": "cell", "number": "111-222-333"}}}`,
+			},
+			{
+				"Set Nested Document",
+				document.NewValuePath("contact.phone.type"),
+				document.NewTextValue("fix"),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [[1, 0, 0], 99, 0]}], "contact": {"phone": {"type": "fix", "number": "111-222-333"}}}`,
+			},
+			{"Set add field into nested document",
+				document.NewValuePath("contact.email"),
+				document.NewTextValue("foo@example.com"),
+				`{"friends": [{"name": "Baz", "address": {"city": "Paris", "zipcode": "75001"}, "a": [[1, 0, 0], 99, 0]}], "contact": {"phone": {"type": "fix", "number": "111-222-333"}, "email": "foo@example.com"}}`,
+			},
+
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				var bufBytes bytes.Buffer
+				require.NoError(t, err, buf.Set(test.p, test.v))
+				err := document.ToJSON(&bufBytes, buf)
+				require.NoError(t, err)
+				require.Equal(t, test.want, bufBytes.String())
+			})
+		}
+
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/sql/parser/update.go
+++ b/sql/parser/update.go
@@ -1,10 +1,11 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/genjidb/genji/sql/planner"
 	"github.com/genjidb/genji/sql/query/expr"
 	"github.com/genjidb/genji/sql/scanner"
-	"strings"
 )
 
 // parseUpdateStatement parses a update string and returns a Statement AST object.
@@ -57,30 +58,24 @@ func (p *Parser) parseSetClause() ([]updateSetPair, error) {
 			}
 		}
 
-		tok, pos, lit := p.ScanIgnoreWhitespace()
-		if tok != scanner.IDENT {
-			return nil, newParseError(scanner.Tokstr(tok, lit), []string{"identifier"}, pos)
-		}
-
-		p.Unscan()
 		ref, err := p.parseFieldRef()
 		if err != nil {
-			return nil, newParseError(scanner.Tokstr(tok, lit), []string{"identifier"}, pos)
+			return nil, err
 		}
 
-		lit = strings.Join(ref, ".")
+		lit := strings.Join(ref, ".")
 		// Scan the eq sign
 		if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.EQ {
 			return nil, newParseError(scanner.Tokstr(tok, lit), []string{"="}, pos)
 		}
 
 		// Scan the expr for the value.
-		expr, _, err := p.ParseExpr()
+		parsedExpr, _, err := p.ParseExpr()
 		if err != nil {
 			return nil, err
 		}
 
-		pairs = append(pairs, updateSetPair{lit, expr})
+		pairs = append(pairs, updateSetPair{lit, parsedExpr})
 		firstPair = false
 	}
 

--- a/sql/parser/update_test.go
+++ b/sql/parser/update_test.go
@@ -42,7 +42,7 @@ func TestParserUpdate(t *testing.T) {
 						planner.NewSelectionNode(
 							planner.NewTableInputNode("test"),
 							expr.Eq(expr.FieldSelector([]string{"age"}), expr.IntegerValue(10)),
-					),
+						),
 						"a.2.a", expr.IntegerValue(1),
 					),
 					"test",

--- a/sql/parser/update_test.go
+++ b/sql/parser/update_test.go
@@ -25,6 +25,29 @@ func TestParserUpdate(t *testing.T) {
 					"test",
 				)),
 			false},
+		{"SET/Dot notation", "UPDATE test SET a.2.a = 1",
+			planner.NewTree(
+				planner.NewReplacementNode(
+					planner.NewSetNode(
+						planner.NewTableInputNode("test"),
+						"a.2.a", expr.IntegerValue(1),
+					),
+					"test",
+				)),
+			false},
+		{"SET/Dot notation with cond", "UPDATE test SET a.2.a = 1 WHERE age = 10",
+			planner.NewTree(
+				planner.NewReplacementNode(
+					planner.NewSetNode(
+						planner.NewSelectionNode(
+							planner.NewTableInputNode("test"),
+							expr.Eq(expr.FieldSelector([]string{"age"}), expr.IntegerValue(10)),
+					),
+						"a.2.a", expr.IntegerValue(1),
+					),
+					"test",
+				)),
+			false},
 		{"SET/With cond", "UPDATE test SET a = 1, b = 2 WHERE age = 10",
 			planner.NewTree(
 				planner.NewReplacementNode(

--- a/sql/planner/tree.go
+++ b/sql/planner/tree.go
@@ -372,7 +372,7 @@ func (n *setNode) toStream(st document.Stream) (document.Stream, error) {
 
 		path := document.NewValuePath(n.field)
 		err = fb.Set(path, ev)
-		
+
 		return &fb, err
 	}), nil
 }

--- a/sql/planner/tree.go
+++ b/sql/planner/tree.go
@@ -370,20 +370,10 @@ func (n *setNode) toStream(st document.Stream) (document.Stream, error) {
 			return nil, err
 		}
 
-		_, err = fb.GetByField(n.field)
-
-		switch err {
-		case nil:
-			// If no error, it means that the field already exists
-			// and it should be replaced.
-			_ = fb.Replace(n.field, ev)
-		case document.ErrFieldNotFound:
-			// If the field doesn't exist,
-			// it should be added to the document.
-			fb.Set(n.field, ev)
-		}
-
-		return &fb, nil
+		path := document.NewValuePath(n.field)
+		err = fb.Set(path, ev)
+		
+		return &fb, err
 	}), nil
 }
 


### PR DESCRIPTION
This PR fixes #84 by a deep recursive course of the document based on the ValuePath.
 #Set method is now taking a ValuePath.
