### PR TITLE
Command .indexes displaying indexes of database or a table.

### DIFF
--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -2,11 +2,16 @@ package shell
 
 import (
 	"fmt"
-
 	"github.com/genjidb/genji"
+	"github.com/genjidb/genji/database"
+	"github.com/genjidb/genji/document"
 )
 
-func runTablesCmd(db *genji.DB) error {
+func runTablesCmd(db *genji.DB, cmd []string) error {
+	if len(cmd) > 1 {
+		return fmt.Errorf("too many arguments in call to %s", cmd[0])
+	}
+
 	var tables []string
 	err := db.View(func(tx *genji.Tx) error {
 		var err error
@@ -23,4 +28,59 @@ func runTablesCmd(db *genji.DB) error {
 	}
 
 	return nil
+}
+
+// runTableIndexCmd shows the all indexes that the given table contains.
+func runTableIndexCmd(db *genji.DB, tableName string) error {
+	err := db.ViewTable(tableName, func(tx *genji.Tx, table *database.Table) error {
+		return table.PrintIndexes()
+	})
+
+	if err == document.ErrFieldNotFound {
+		return nil
+	}
+
+	return err
+}
+
+// runAllIndexesCmd shows all indexes that the database contains.
+func runAllIndexesCmd(db *genji.DB) error {
+	var tables []string
+	err := db.View(func(tx *genji.Tx) error {
+		var err error
+		tables, err = tx.ListTables()
+		return err
+	})
+
+	if err != nil {
+		return err
+	}
+
+	for _, table := range tables {
+		// If there is no index in a table we continue to the next. No error handling needed
+		_ = db.View(func(tx *genji.Tx) error {
+			t, err := tx.GetTable(table)
+			if err != nil {
+				return err
+			}
+
+			return t.PrintIndexes()
+		})
+	}
+
+	return nil
+}
+
+// runIndexesCmd select a kind of indexes command is wanted
+func runIndexesCmd(db *genji.DB, in []string) error {
+	switch len(in) {
+	case 1:
+		// If the input is ".Indexes"
+		return runAllIndexesCmd(db)
+	case 2:
+		// If the input is ".Indexes <tableName>" cmd[1] is the table name
+		return runTableIndexCmd(db, in[1])
+	}
+
+	return fmt.Errorf("too many arguments in call to %s", in[0])
 }

--- a/cmd/genji/shell/command_test.go
+++ b/cmd/genji/shell/command_test.go
@@ -1,0 +1,83 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/genjidb/genji"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunTablesCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{
+			"Table",
+			".tables",
+			false,
+		},
+		{
+			"Table with options",
+			".tables test",
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := genji.Open(":memory:")
+			require.NoError(t, err)
+			defer db.Close()
+
+			if err := displayTableIndex(db, test.in); (err != nil) != test.wantErr {
+				require.Errorf(t, err, "", test.wantErr)
+			}
+		})
+	}
+}
+
+func TestIndexesCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		wantErr bool
+	}{
+		{
+			".Indexes",
+			strings.Fields(".indexes"),
+			false,
+		},
+		{
+			"Indexes with table name",
+			strings.Fields(".indexes test"),
+			false,
+		},
+		{
+			"Indexes with nonexistent table name",
+			strings.Fields(".indexes foo"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := genji.Open(":memory:")
+			require.NoError(t, err)
+			defer db.Close()
+
+			err = db.Exec("CREATE TABLE test")
+			require.NoError(t, err)
+			err = db.Exec(`
+						CREATE INDEX idx_a ON test (a);
+						CREATE INDEX idx_b ON test (b);
+						CREATE INDEX idx_c ON test (c);
+					`)
+			require.NoError(t, err)
+			if err := runIndexesCmd(db, test.in); (err != nil) != test.wantErr {
+				require.Errorf(t, err, "", test.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -189,7 +189,7 @@ func (sh *Shell) executeInput(in string) error {
 	switch {
 	// if it starts with a "." it's a command
 	// it must not be in the middle of a multi line query though
-	case strings.HasPrefix(in, ".") && sh.query == "":
+	case strings.HasPrefix(in, "."):
 		return sh.runCommand(in)
 	// If it ends with a ";" we can run a query
 	case strings.HasSuffix(in, ";"):
@@ -202,6 +202,7 @@ func (sh *Shell) executeInput(in string) error {
 	// If the input is empty we ignore it
 	case in == "":
 		return nil
+
 	// If we reach this case, it means the user is in the middle of a
 	// multi line query. We change the prompt and set the multiLine var to true.
 	default:
@@ -213,16 +214,29 @@ func (sh *Shell) executeInput(in string) error {
 	return nil
 }
 
-func (sh *Shell) runCommand(cmd string) error {
-	switch cmd {
+func (sh *Shell) runCommand(in string) error {
+	cmd := strings.Fields(in)
+	switch cmd[0] {
 	case ".tables":
 		db, err := sh.getDB()
 		if err != nil {
 			return err
 		}
-		return runTablesCmd(db)
+
+		return runTablesCmd(db, cmd)
 	case ".exit":
+		if len(cmd) > 1 {
+			return fmt.Errorf("too many arguments in call to %s", cmd[0])
+		}
+
 		os.Exit(0)
+	case ".indexes":
+		db, err := sh.getDB()
+		if err != nil {
+			return err
+		}
+
+		return runIndexesCmd(db, cmd)
 	}
 
 	return fmt.Errorf("unknown command %q", cmd)

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -226,7 +226,7 @@ func (sh *Shell) runCommand(in string) error {
 		return runTablesCmd(db, cmd)
 	case ".exit":
 		if len(cmd) > 1 {
-			return fmt.Errorf("too many arguments in call to %s", cmd[0])
+			return fmt.Errorf("usage: .exit")
 		}
 
 		os.Exit(0)

--- a/database/config.go
+++ b/database/config.go
@@ -237,12 +237,12 @@ func generateStoreID() [6]byte {
 
 // IndexConfig holds the configuration of an index.
 type IndexConfig struct {
+	TableName string
+	IndexName string
+	Path      document.ValuePath
+
 	// If set to true, values will be associated with at most one key. False by default.
 	Unique bool
-
-	IndexName string
-	TableName string
-	Path      document.ValuePath
 }
 
 // ToDocument creates a document from an IndexConfig.
@@ -297,11 +297,7 @@ func (i *IndexConfig) ScanDocument(d document.Document) error {
 // the index configuration and provides methods to manipulate the index.
 type Index struct {
 	index.Index
-
-	IndexName string
-	TableName string
-	Path      document.ValuePath
-	Unique    bool
+	Opts IndexConfig
 }
 
 type indexStore struct {

--- a/database/table.go
+++ b/database/table.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -376,7 +375,7 @@ func (t *Table) Insert(d document.Document) ([]byte, error) {
 	}
 
 	for _, idx := range indexes {
-		v, err := idx.Path.GetValue(d)
+		v, err := idx.Opts.Path.GetValue(d)
 		if err != nil {
 			v = document.NewNullValue()
 		}
@@ -408,7 +407,7 @@ func (t *Table) Delete(key []byte) error {
 	}
 
 	for _, idx := range indexes {
-		v, err := idx.Path.GetValue(d)
+		v, err := idx.Opts.Path.GetValue(d)
 		if err != nil {
 			return err
 		}
@@ -448,7 +447,7 @@ func (t *Table) replace(indexes map[string]Index, key []byte, d document.Documen
 
 	// remove key from indexes
 	for _, idx := range indexes {
-		v, err := idx.Path.GetValue(old)
+		v, err := idx.Opts.Path.GetValue(old)
 		if err != nil {
 			return err
 		}
@@ -473,7 +472,7 @@ func (t *Table) replace(indexes map[string]Index, key []byte, d document.Documen
 
 	// update indexes
 	for _, idx := range indexes {
-		v, err := idx.Path.GetValue(d)
+		v, err := idx.Opts.Path.GetValue(d)
 		if err != nil {
 			continue
 		}
@@ -542,11 +541,8 @@ func (t *Table) Indexes() (map[string]Index, error) {
 			}
 
 			indexes[opts.Path.String()] = Index{
-				Index:     idx,
-				IndexName: opts.IndexName,
-				TableName: opts.TableName,
-				Path:      opts.Path,
-				Unique:    opts.Unique,
+				Index: idx,
+				Opts:  opts,
 			}
 
 			return nil
@@ -556,19 +552,4 @@ func (t *Table) Indexes() (map[string]Index, error) {
 	}
 
 	return indexes, nil
-}
-
-// PrintIndexes prints all indexes of the table receiver.
-func (t *Table) PrintIndexes() error {
-	indexes, err := t.Indexes()
-	for _, idx := range indexes {
-		j, err := json.MarshalIndent(&idx, "", " ")
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(string(j))
-	}
-
-	return err
 }

--- a/database/table.go
+++ b/database/table.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -555,4 +556,19 @@ func (t *Table) Indexes() (map[string]Index, error) {
 	}
 
 	return indexes, nil
+}
+
+// PrintIndexes prints all indexes of the table receiver.
+func (t *Table) PrintIndexes() error {
+	indexes, err := t.Indexes()
+	for _, idx := range indexes {
+		j, err := json.MarshalIndent(&idx, "", " ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(j))
+	}
+
+	return err
 }

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -185,11 +185,8 @@ func (tx Transaction) GetIndex(name string) (*Index, error) {
 	}
 
 	return &Index{
-		Index:     idx,
-		IndexName: opts.IndexName,
-		TableName: opts.TableName,
-		Path:      opts.Path,
-		Unique:    opts.Unique,
+		Index: idx,
+		Opts:  *opts,
 	}, nil
 }
 
@@ -226,7 +223,7 @@ func (tx Transaction) ReIndex(indexName string) error {
 		return err
 	}
 
-	tb, err := tx.GetTable(idx.TableName)
+	tb, err := tx.GetTable(idx.Opts.TableName)
 	if err != nil {
 		return err
 	}
@@ -237,7 +234,7 @@ func (tx Transaction) ReIndex(indexName string) error {
 	}
 
 	return tb.Iterate(func(d document.Document) error {
-		v, err := idx.Path.GetValue(d)
+		v, err := idx.Opts.Path.GetValue(d)
 		if err != nil {
 			return err
 		}

--- a/sql/planner/optimizer.go
+++ b/sql/planner/optimizer.go
@@ -398,7 +398,7 @@ func selectionNodeValidForIndex(sn *selectionNode, tableName string, indexes map
 		return nil
 	}
 
-	in := NewIndexInputNode(tableName, idx.IndexName, iop, e, scanner.ASC).(*indexInputNode)
+	in := NewIndexInputNode(tableName, idx.Opts.IndexName, iop, e, scanner.ASC).(*indexInputNode)
 	in.index = idx
 
 	return in

--- a/sql/query/plan.go
+++ b/sql/query/plan.go
@@ -212,7 +212,7 @@ func (qo *queryOptimizer) analyseExpr(e expr.Expr) *queryPlanField {
 				indexedField: fs,
 				op:           op,
 				e:            e,
-				uniqueIndex:  idx.Unique,
+				uniqueIndex:  idx.Opts.Unique,
 			}
 		}
 


### PR DESCRIPTION
This PR fixes #100. Two options for the command `.Indexes` and `.Indexes <table name>` are implemented. Tests `.tables` and `.indexes` are added. 

```
genji> .indexes
main skill index on users(skills.0)
idx_nen on users(nen)
genji>
```

Refactoring of  `struct Index`. Let me know what you think about it