### PR TITLE
Remove unnecessary db methods

### DIFF
--- a/db.go
+++ b/db.go
@@ -118,33 +118,6 @@ func (db *DB) QueryDocument(q string, args ...interface{}) (document.Document, e
 	return &fb, nil
 }
 
-// ViewTable starts a read only transaction, fetches the selected table, calls fn with that table
-// and automatically rolls back the transaction.
-func (db *DB) ViewTable(tableName string, fn func(*Tx, *database.Table) error) error {
-	return db.View(func(tx *Tx) error {
-		tb, err := tx.GetTable(tableName)
-		if err != nil {
-			return err
-		}
-
-		return fn(tx, tb)
-	})
-}
-
-// UpdateTable starts a read/write transaction, fetches the selected table, calls fn with that table
-// and automatically commits the transaction.
-// If fn returns an error, the transaction is rolled back.
-func (db *DB) UpdateTable(tableName string, fn func(*Tx, *database.Table) error) error {
-	return db.Update(func(tx *Tx) error {
-		tb, err := tx.GetTable(tableName)
-		if err != nil {
-			return err
-		}
-
-		return fn(tx, tb)
-	})
-}
-
 // Tx represents a database transaction. It provides methods for managing the
 // collection of tables and the transaction itself.
 // Tx is either read-only or read/write. Read-only can be used to read tables

--- a/sql/query/create_test.go
+++ b/sql/query/create_test.go
@@ -37,8 +37,9 @@ func TestCreateTable(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			err = db.ViewTable("test", func(_ *genji.Tx, _ *database.Table) error {
-				return nil
+			err = db.View(func(tx *genji.Tx) error {
+				_, err := tx.GetTable("test")
+				return err
 			})
 			require.NoError(t, err)
 		})
@@ -53,7 +54,12 @@ func TestCreateTable(t *testing.T) {
 			err = db.Exec(`CREATE TABLE test(d double, b bool)`)
 			require.NoError(t, err)
 
-			err = db.ViewTable("test", func(_ *genji.Tx, tb *database.Table) error {
+			err = db.View(func(tx *genji.Tx) error {
+				tb, err := tx.GetTable("test")
+				if err != nil {
+					return err
+				}
+
 				info, err := tb.Info()
 				if err != nil {
 					return err
@@ -78,7 +84,11 @@ func TestCreateTable(t *testing.T) {
 			`)
 			require.NoError(t, err)
 
-			err = db.ViewTable("test1", func(_ *genji.Tx, tb *database.Table) error {
+			err = db.View(func(tx *genji.Tx) error {
+				tb, err := tx.GetTable("test1")
+				if err != nil {
+					return err
+				}
 				info, err := tb.Info()
 				if err != nil {
 					return err


### PR DESCRIPTION
`ViewTable` and `UpdateTable` used to be useful when Genji was doing code generation and before the introduction of SQL. They were used to limit the number of lines of generated code.
They no longer make sense now as we want to encourage users to use SQL as much as possible.
If there is a need to access tables, there is still the `View` and `Update` methods.
Please let me know if you think otherwise