### PR TITLE
Rename convert methods

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -110,7 +110,7 @@ func (ti *TableInfo) ScanDocument(d document.Document) error {
 	if err != nil {
 		return err
 	}
-	b, err := v.ConvertToBlob()
+	b, err := v.ConvertToBytes()
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func (i *IndexConfig) ScanDocument(d document.Document) error {
 	if err != nil {
 		return err
 	}
-	i.IndexName, err = v.ConvertToText()
+	i.IndexName, err = v.ConvertToString()
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (i *IndexConfig) ScanDocument(d document.Document) error {
 	if err != nil {
 		return err
 	}
-	i.TableName, err = v.ConvertToText()
+	i.TableName, err = v.ConvertToString()
 	if err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ func arrayToValuePath(v document.Value) (document.ValuePath, error) {
 	var path document.ValuePath
 
 	err = ar.Iterate(func(_ int, value document.Value) error {
-		p, err := value.ConvertToText()
+		p, err := value.ConvertToString()
 		if err != nil {
 			return err
 		}

--- a/database/table.go
+++ b/database/table.go
@@ -518,7 +518,7 @@ func (t *Table) Indexes() (map[string]Index, error) {
 				return false, err
 			}
 
-			b, err := v.ConvertToBlob()
+			b, err := v.ConvertToBytes()
 			if err != nil {
 				return false, err
 			}

--- a/document/encoding/encoding.go
+++ b/document/encoding/encoding.go
@@ -220,13 +220,13 @@ func EncodeValue(v document.Value) ([]byte, error) {
 		}
 		return msgpack.EncodeArray(a)
 	case document.BlobValue:
-		x, err := v.ConvertToBlob()
+		x, err := v.ConvertToBytes()
 		if err != nil {
 			return nil, err
 		}
 		return x, nil
 	case document.TextValue:
-		x, err := v.ConvertToText()
+		x, err := v.ConvertToString()
 		if err != nil {
 			return nil, err
 		}

--- a/document/encoding/msgpack/codec.go
+++ b/document/encoding/msgpack/codec.go
@@ -114,13 +114,13 @@ func (e *Encoder) EncodeValue(v document.Value) error {
 	case document.NullValue:
 		return e.enc.EncodeNil()
 	case document.TextValue:
-		s, err := v.ConvertToText()
+		s, err := v.ConvertToString()
 		if err != nil {
 			return err
 		}
 		return e.enc.EncodeString(s)
 	case document.BlobValue:
-		b, err := v.ConvertToBlob()
+		b, err := v.ConvertToBytes()
 		if err != nil {
 			return err
 		}

--- a/document/json.go
+++ b/document/json.go
@@ -42,7 +42,7 @@ func (v Value) MarshalJSON() ([]byte, error) {
 		}
 		return jsonArray{a}.MarshalJSON()
 	case TextValue, BlobValue:
-		s, err := v.ConvertToText()
+		s, err := v.ConvertToString()
 		if err != nil {
 			return nil, err
 		}
@@ -411,8 +411,8 @@ func (v Value) Compare(u Value) int {
 
 	// compare byte arrays and strings
 	if (v.Type == TextValue || v.Type == BlobValue) && (u.Type == TextValue || u.Type == BlobValue) {
-		bv, _ := v.ConvertToBlob()
-		bu, _ := u.ConvertToBlob()
+		bv, _ := v.ConvertToBytes()
+		bu, _ := u.ConvertToBytes()
 		return bytesutil.CompareBytes(bv, bu)
 	}
 

--- a/document/scan.go
+++ b/document/scan.go
@@ -245,7 +245,7 @@ func scanValue(v Value, ref reflect.Value) error {
 
 	switch ref.Kind() {
 	case reflect.String:
-		x, err := v.ConvertToText()
+		x, err := v.ConvertToString()
 		if err != nil {
 			return err
 		}
@@ -291,7 +291,7 @@ func scanValue(v Value, ref reflect.Value) error {
 		return structScan(d, ref)
 	case reflect.Slice:
 		if ref.Type().Elem().Kind() == reflect.Uint8 {
-			x, err := v.ConvertToBlob()
+			x, err := v.ConvertToBytes()
 			if err != nil {
 				return err
 			}

--- a/document/value.go
+++ b/document/value.go
@@ -253,13 +253,13 @@ func (v Value) ConvertTo(t ValueType) (Value, error) {
 		}
 		return NewDurationValue(x), nil
 	case BlobValue:
-		x, err := v.ConvertToBlob()
+		x, err := v.ConvertToBytes()
 		if err != nil {
 			return Value{}, err
 		}
 		return NewBlobValue(x), nil
 	case TextValue:
-		x, err := v.ConvertToText()
+		x, err := v.ConvertToString()
 		if err != nil {
 			return Value{}, err
 		}
@@ -269,9 +269,9 @@ func (v Value) ConvertTo(t ValueType) (Value, error) {
 	return Value{}, fmt.Errorf("cannot convert %q to %q", v.Type, t)
 }
 
-// ConvertToBlob converts a value of type Text or Blob to a slice of bytes.
+// ConvertToBytes converts a value of type Text or Blob to a slice of bytes.
 // If fails if it's used with any other type.
-func (v Value) ConvertToBlob() ([]byte, error) {
+func (v Value) ConvertToBytes() ([]byte, error) {
 	switch v.Type {
 	case TextValue, BlobValue:
 		return v.V.([]byte), nil
@@ -284,9 +284,9 @@ func (v Value) ConvertToBlob() ([]byte, error) {
 	return nil, fmt.Errorf(`cannot convert %q to "bytes"`, v.Type)
 }
 
-// ConvertToText turns a value of type Text or Blob into a string.
+// ConvertToString turns a value of type Text or Blob into a string.
 // If fails if it's used with any other type.
-func (v Value) ConvertToText() (string, error) {
+func (v Value) ConvertToString() (string, error) {
 	switch v.Type {
 	case TextValue, BlobValue:
 		return string(v.V.([]byte)), nil


### PR DESCRIPTION
The names `ConvertToBlob` and `ConvertToText` don't really make sense because these functions are used to get respectively get a []byte and string out of a value. 
