### PR TITLE
Store table information in memory

### DIFF
--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -9,10 +9,8 @@ import (
 func runTablesCmd(db *genji.DB) error {
 	var tables []string
 	err := db.View(func(tx *genji.Tx) error {
-		var err error
-
-		tables, err = tx.ListTables()
-		return err
+		tables = tx.ListTables()
+		return nil
 	})
 	if err != nil {
 		return err

--- a/database/config.go
+++ b/database/config.go
@@ -154,9 +154,7 @@ type tableInfoStore struct {
 }
 
 func newTableInfoStore(tx engine.Transaction) (*tableInfoStore, error) {
-	ts := tableInfoStore{
-		tableInfos: make(map[string]TableInfo),
-	}
+	var ts tableInfoStore
 
 	err := ts.loadAllTableInfo(tx)
 	if err != nil {
@@ -245,7 +243,7 @@ func (t *tableInfoStore) Delete(tx engine.Transaction, tableName string) error {
 
 	delete(t.tableInfos, tableName)
 
-	return err
+	return nil
 }
 
 func (t *tableInfoStore) loadAllTableInfo(tx engine.Transaction) error {

--- a/database/config.go
+++ b/database/config.go
@@ -258,6 +258,7 @@ func (t *tableInfoStore) loadAllTableInfo(tx engine.Transaction) error {
 	}
 
 	it := st.NewIterator(engine.IteratorConfig{})
+	defer it.Close()
 
 	t.tableInfos = make(map[string]TableInfo)
 	var b []byte
@@ -276,7 +277,8 @@ func (t *tableInfoStore) loadAllTableInfo(tx engine.Transaction) error {
 
 		t.tableInfos[string(itm.Key())] = ti
 	}
-	return it.Close()
+
+	return nil
 }
 
 // ListTables lists all the tables.

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -70,7 +70,7 @@ func (tx Transaction) CreateTable(name string, info *TableInfo) error {
 	if info == nil {
 		info = new(TableInfo)
 	}
-	sid, err := tx.tableInfoStore.Insert(name, info)
+	sid, err := tx.tableInfoStore.Insert(tx.Tx, name, info)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (tx Transaction) DropTable(name string) error {
 		return err
 	}
 
-	err = tx.tableInfoStore.Delete(name)
+	err = tx.tableInfoStore.Delete(tx.Tx, name)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (tx Transaction) DropTable(name string) error {
 
 // ListTables lists all the tables.
 // The returned slice is lexicographically ordered.
-func (tx Transaction) ListTables() ([]string, error) {
+func (tx Transaction) ListTables() []string {
 	return tx.tableInfoStore.ListTables()
 }
 
@@ -267,16 +267,6 @@ func (tx Transaction) ReIndexAll() error {
 	}
 
 	return nil
-}
-
-func (tx *Transaction) getTableInfoStore() (*tableInfoStore, error) {
-	st, err := tx.Tx.GetStore([]byte(tableInfoStoreName))
-	if err != nil {
-		return nil, err
-	}
-	return &tableInfoStore{
-		st: st,
-	}, nil
 }
 
 func (tx *Transaction) getIndexStore() (*indexStore, error) {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -79,11 +79,10 @@ func TestTxTable(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		tables, err := tx.ListTables()
-		require.NoError(t, err)
+		tables := tx.ListTables()
 		require.Len(t, tables, 0)
 
-		err = tx.CreateTable("foo", nil)
+		err := tx.CreateTable("foo", nil)
 		require.NoError(t, err)
 
 		err = tx.CreateTable("bar", nil)
@@ -92,9 +91,7 @@ func TestTxTable(t *testing.T) {
 		err = tx.CreateTable("baz", nil)
 		require.NoError(t, err)
 
-		tables, err = tx.ListTables()
-		require.NoError(t, err)
-
+		tables = tx.ListTables()
 		// The returned slice should be lexicographically ordered.
 		exp := []string{"bar", "baz", "foo"}
 		require.Equal(t, exp, tables)

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -30,10 +30,8 @@ func TestDropTable(t *testing.T) {
 	// Assert that only the table `test1` has been dropped.
 	var tables []string
 	err = db.View(func(tx *genji.Tx) error {
-		var err error
-
-		tables, err = tx.ListTables()
-		return err
+		tables = tx.ListTables()
+		return nil
 	})
 	require.Len(t, tables, 2)
 }


### PR DESCRIPTION
This PR makes `tableInfoStore` keep table information in memory. Table information is loaded at database startup and kept up to date every time a table is created, altered or dropped.
This change allows us to have access to table information without the need for a transaction, which is handy if we need to use this during parsing time.

It also fixes a bug where duplicate generated store id was overwritten.