### PR TITLE
Read values from store lazily

### DIFF
--- a/sql/planner/projection.go
+++ b/sql/planner/projection.go
@@ -70,12 +70,13 @@ func (n *ProjectionNode) toStream(st document.Stream) (document.Stream, error) {
 		return document.NewStream(document.NewIterator(fb)), nil
 	}
 
+	var dm documentMask
 	return st.Map(func(d document.Document) (document.Document, error) {
-		return documentMask{
-			info:         n.info,
-			r:            d,
-			resultFields: n.Expressions,
-		}, nil
+		dm.info = n.info
+		dm.r = d
+		dm.resultFields = n.Expressions
+
+		return &dm, nil
 	}), nil
 }
 


### PR DESCRIPTION
This change adds a few optimizations on how memory is handled during iteration. It removes some unnecessary memory allocations by reusing struct values and buffers between each iteration.
It also lazily calls `ValueCopy` so that it's only called when we want to actually read the document. This is useful for queries that don't necessarily need to read some documents (i.e. `SELECT COUNT(*)`)
