### PR TITLE
Remove transaction promotion

### DIFF
--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/genjidb/genji/document"
@@ -41,27 +40,6 @@ func (tx *Transaction) Commit() error {
 // Writable indicates if the transaction is writable or not.
 func (tx *Transaction) Writable() bool {
 	return tx.writable
-}
-
-// Promote rollsback a read-only transaction and begins a read-write transaction transparently.
-// It returns an error if the current transaction is already writable.
-func (tx *Transaction) Promote() error {
-	if tx.writable {
-		return errors.New("cannot promote a writable transaction")
-	}
-
-	err := tx.Rollback()
-	if err != nil {
-		return err
-	}
-
-	newTransaction, err := tx.db.Begin(true)
-	if err != nil {
-		return err
-	}
-
-	*tx = *newTransaction
-	return nil
 }
 
 // CreateTable creates a table with the given name.

--- a/db.go
+++ b/db.go
@@ -134,7 +134,7 @@ func (tx *Tx) Query(q string, args ...interface{}) (*query.Result, error) {
 		return nil, err
 	}
 
-	return pq.Exec(tx.Transaction, argsToParams(args), false)
+	return pq.Exec(tx.Transaction, argsToParams(args))
 }
 
 // QueryDocument runs the query and returns the first document.

--- a/db_test.go
+++ b/db_test.go
@@ -18,7 +18,7 @@ func ExampleTx() {
 	}
 	defer db.Close()
 
-	tx, err := db.Begin(false)
+	tx, err := db.Begin(true)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/query/query.go
+++ b/sql/query/query.go
@@ -61,22 +61,12 @@ func (q Query) Run(db *database.Database, args []expr.Param) (*Result, error) {
 	return &res, nil
 }
 
-// Exec the query within the given transaction. If the one of the statements requires a read-write
-// transaction and tx is not, tx will get promoted.
-func (q Query) Exec(tx *database.Transaction, args []expr.Param, forceReadOnly bool) (*Result, error) {
+// Exec the query within the given transaction.
+func (q Query) Exec(tx *database.Transaction, args []expr.Param) (*Result, error) {
 	var res Result
 	var err error
 
 	for _, stmt := range q.Statements {
-		// if the statement requires a writable transaction,
-		// promote the current transaction.
-		if !forceReadOnly && !tx.Writable() && !stmt.IsReadOnly() {
-			err := tx.Promote()
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		res, err = stmt.Run(tx, args)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR removes the transaction promotion feature. This feature was wrongly implemented, as it's not currently possible to promote a transaction in Bolt or Badger.