### PR TITLE
Fix bad tableInfoStore state on rollback

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -104,8 +104,3 @@ func (db *Database) Begin(writable bool) (*Transaction, error) {
 
 	return &tx, nil
 }
-
-// GetTableInfo returns a map containing information about all the tables.
-func (db *Database) GetTableInfo() map[string]TableInfo {
-	return db.tableInfoStore.GetTableInfo()
-}

--- a/database/table.go
+++ b/database/table.go
@@ -24,12 +24,7 @@ type Table struct {
 
 // Info of the table.
 func (t *Table) Info() (*TableInfo, error) {
-	ti, err := t.infoStore.Get(t.name)
-	if err != nil {
-		return nil, err
-	}
-
-	return ti, nil
+	return t.infoStore.Get(t.tx, t.name)
 }
 
 // Name returns the name of the table.
@@ -348,7 +343,7 @@ func (t *Table) GetDocument(key []byte) (document.Document, error) {
 // if there are no primary key in the table, a default
 // key is generated, called the docid.
 func (t *Table) generateKey(d document.Document) ([]byte, error) {
-	ti, err := t.infoStore.Get(t.name)
+	ti, err := t.infoStore.Get(t.tx, t.name)
 	if err != nil {
 		return nil, err
 	}

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -46,23 +46,20 @@ func TestTxTable(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		tx, err := db.Begin(true)
-		require.NoError(t, err)
+		check := func() {
+			tx, err := db.Begin(true)
+			require.NoError(t, err)
+			defer func() {
+				err = tx.Rollback()
+				require.NoError(t, err)
+			}()
 
-		err = tx.CreateTable("test", nil)
-		require.NoError(t, err)
+			err = tx.CreateTable("test", nil)
+			require.NoError(t, err)
+		}
 
-		err = tx.Rollback()
-		require.NoError(t, err)
-
-		tx, err = db.Begin(true)
-		require.NoError(t, err)
-
-		err = tx.CreateTable("test", nil)
-		require.NoError(t, err)
-
-		err = tx.Rollback()
-		require.NoError(t, err)
+		check()
+		check()
 	})
 
 	t.Run("Get", func(t *testing.T) {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -41,6 +41,30 @@ func TestTxTable(t *testing.T) {
 		require.EqualError(t, err, database.ErrTableAlreadyExists.Error())
 	})
 
+	t.Run("Create and rollback", func(t *testing.T) {
+		db, err := database.New(memoryengine.NewEngine())
+		require.NoError(t, err)
+		defer db.Close()
+
+		tx, err := db.Begin(true)
+		require.NoError(t, err)
+
+		err = tx.CreateTable("test", nil)
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		tx, err = db.Begin(true)
+		require.NoError(t, err)
+
+		err = tx.CreateTable("test", nil)
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+	})
+
 	t.Run("Get", func(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()


### PR DESCRIPTION
Since we started keeping table information in memory, we introduced a bug that prevents us from creating a table if this one has already been created during a transaction, then that transaction rolls back:

- Tx A creates a table named `foo`
- Tx A rolls back
- Tx B creates a table name `foo` -> Table already exists

This PR introduces transaction isolation at the tableInfoStore level by using transaction ids to hide tables that haven't been committed from other transactions.
That way, transactions are not aware of tables that have been created in transactions that haven't been committed yet, EXCEPT when other transactions attempt to create a table with the same name.
