### PR TITLE
Expose __genji_tables

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -279,7 +279,8 @@ func (t *tableInfoStore) loadAllTableInfo(tx engine.Transaction) error {
 	}
 
 	t.tableInfos[tableInfoStoreName] = TableInfo{
-		storeID: []byte(tableInfoStoreName),
+		storeID:  []byte(tableInfoStoreName),
+		readOnly: true,
 	}
 	return nil
 }

--- a/database/config.go
+++ b/database/config.go
@@ -5,8 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -319,31 +317,6 @@ func (t *tableInfoStore) commit(tx *Transaction) {
 			t.tableInfos[k] = info
 		}
 	}
-}
-
-// ListTables lists all the tables. It ignores tables created by
-// other transactions that haven't been commited yet.
-// The returned slice is lexicographically ordered.
-func (t *tableInfoStore) ListTables(tx *Transaction) []string {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	names := make([]string, 0, len(t.tableInfos))
-	for k := range t.tableInfos {
-		if t.tableInfos[k].transactionID != 0 && t.tableInfos[k].transactionID != tx.id {
-			continue
-		}
-
-		if strings.HasPrefix(k, internalPrefix) {
-			continue
-		}
-
-		names = append(names, k)
-	}
-
-	sort.Strings(names)
-
-	return names
 }
 
 // GetTableInfo returns a copy of all the table information.

--- a/database/config.go
+++ b/database/config.go
@@ -68,6 +68,7 @@ func (f *FieldConstraint) ScanDocument(d document.Document) error {
 }
 
 type TableInfo struct {
+	tableName string
 	// storeID is used as a key to reference a table.
 	storeID  []byte
 	readOnly bool
@@ -93,6 +94,7 @@ func (ti *TableInfo) GetPrimaryKey() *FieldConstraint {
 func (ti *TableInfo) ToDocument() document.Document {
 	buf := document.NewFieldBuffer()
 
+	buf.Add("table_name", document.NewTextValue(ti.tableName))
 	buf.Add("store_id", document.NewBlobValue(ti.storeID))
 
 	vbuf := document.NewValueBuffer()
@@ -107,7 +109,13 @@ func (ti *TableInfo) ToDocument() document.Document {
 }
 
 func (ti *TableInfo) ScanDocument(d document.Document) error {
-	v, err := d.GetByField("store_id")
+	v, err := d.GetByField("table_name")
+	if err != nil {
+		return err
+	}
+	ti.tableName = v.V.(string)
+
+	v, err = d.GetByField("store_id")
 	if err != nil {
 		return err
 	}

--- a/database/config.go
+++ b/database/config.go
@@ -93,7 +93,7 @@ func (ti *TableInfo) GetPrimaryKey() *FieldConstraint {
 func (ti *TableInfo) ToDocument() document.Document {
 	buf := document.NewFieldBuffer()
 
-	buf.Add("storeID", document.NewBlobValue(ti.storeID))
+	buf.Add("store_id", document.NewBlobValue(ti.storeID))
 
 	vbuf := document.NewValueBuffer()
 	for _, fc := range ti.FieldConstraints {
@@ -107,7 +107,7 @@ func (ti *TableInfo) ToDocument() document.Document {
 }
 
 func (ti *TableInfo) ScanDocument(d document.Document) error {
-	v, err := d.GetByField("storeID")
+	v, err := d.GetByField("store_id")
 	if err != nil {
 		return err
 	}

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -43,9 +43,8 @@ func TestTableInfoStore(t *testing.T) {
 		require.Equal(t, []string{"foo1", "foo2", "foo3"}, lt)
 
 		// Getting an existing TableInfo should work.
-		received, err := tx.tableInfoStore.Get(tx, "foo1")
+		_, err = tx.tableInfoStore.Get(tx, "foo1")
 		require.NoError(t, err)
-		require.NotNil(t, received.storeID)
 
 		// Getting a non-existing TableInfo should not work.
 		_, err = tx.tableInfoStore.Get(tx, "unknown")

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -35,13 +35,6 @@ func TestTableInfoStore(t *testing.T) {
 		err = tx.tableInfoStore.Insert(tx, "foo1", info)
 		require.Equal(t, err, ErrTableAlreadyExists)
 
-		// Listing all tables should return their name
-		// lexicographically ordered.
-		_ = tx.tableInfoStore.Insert(tx, "foo3", info)
-		_ = tx.tableInfoStore.Insert(tx, "foo2", info)
-		lt := tx.tableInfoStore.ListTables(tx)
-		require.Equal(t, []string{"foo1", "foo2", "foo3"}, lt)
-
 		// Getting an existing TableInfo should work.
 		_, err = tx.tableInfoStore.Get(tx, "foo1")
 		require.NoError(t, err)

--- a/database/table.go
+++ b/database/table.go
@@ -42,7 +42,16 @@ func (t *Table) Truncate() error {
 // in the given document.
 // If no primary key has been selected, a monotonic autoincremented integer key will be generated.
 func (t *Table) Insert(d document.Document) ([]byte, error) {
-	d, err := t.ValidateConstraints(d)
+	info, err := t.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	if info.readOnly {
+		return nil, errors.New("cannot write to read-only table")
+	}
+
+	d, err = t.ValidateConstraints(d)
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +108,15 @@ func (t *Table) Insert(d document.Document) ([]byte, error) {
 // Delete a document by key.
 // Indexes are automatically updated.
 func (t *Table) Delete(key []byte) error {
+	info, err := t.Info()
+	if err != nil {
+		return err
+	}
+
+	if info.readOnly {
+		return errors.New("cannot write to read-only table")
+	}
+
 	d, err := t.GetDocument(key)
 	if err != nil {
 		return err
@@ -128,7 +146,16 @@ func (t *Table) Delete(key []byte) error {
 // An error is returned if the key doesn't exist.
 // Indexes are automatically updated.
 func (t *Table) Replace(key []byte, d document.Document) error {
-	d, err := t.ValidateConstraints(d)
+	info, err := t.Info()
+	if err != nil {
+		return err
+	}
+
+	if info.readOnly {
+		return errors.New("cannot write to read-only table")
+	}
+
+	d, err = t.ValidateConstraints(d)
 	if err != nil {
 		return err
 	}
@@ -587,6 +614,15 @@ func getParentValue(d document.Document, p document.ValuePath) (document.Value, 
 
 // ReIndex all the indexes of the table.
 func (t *Table) ReIndex() error {
+	info, err := t.Info()
+	if err != nil {
+		return err
+	}
+
+	if info.readOnly {
+		return errors.New("cannot write to read-only table")
+	}
+
 	indexes, err := t.Indexes()
 	if err != nil {
 		return err

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -64,6 +64,7 @@ func (tx *Transaction) CreateTable(name string, info *TableInfo) error {
 	}
 
 	info.storeID = tx.tableInfoStore.generateStoreID()
+	info.tableName = name
 	err := tx.tableInfoStore.Insert(tx, name, info)
 	if err != nil {
 		return err

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -63,8 +63,8 @@ func (tx *Transaction) CreateTable(name string, info *TableInfo) error {
 		info = new(TableInfo)
 	}
 
-	info.storeID = tx.tableInfoStore.generateStoreID()
 	info.tableName = name
+	info.storeID = tx.tableInfoStore.generateStoreID()
 	err := tx.tableInfoStore.Insert(tx, name, info)
 	if err != nil {
 		return err
@@ -110,6 +110,7 @@ func (tx *Transaction) RenameTable(oldName, newName string) error {
 		return errors.New("cannot write to read-only table")
 	}
 
+	ti.tableName = newName
 	// Insert the TableInfo keyed by the newName name.
 	err = tx.tableInfoStore.Insert(tx, newName, ti)
 	if err != nil {
@@ -186,12 +187,6 @@ func (tx *Transaction) DropTable(name string) error {
 	}
 
 	return tx.Tx.DropStore(ti.storeID)
-}
-
-// ListTables lists all the tables.
-// The returned slice is lexicographically ordered.
-func (tx *Transaction) ListTables() []string {
-	return tx.tableInfoStore.ListTables(tx)
 }
 
 // CreateIndex creates an index with the given name.

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -26,7 +26,6 @@ func newTestDB(t testing.TB) (*database.Transaction, func()) {
 // - CreateTable
 // - GetTable
 // - DropTable
-// - ListTables
 // - RenameTable
 func TestTxTable(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
@@ -101,28 +100,6 @@ func TestTxTable(t *testing.T) {
 		require.EqualError(t, err, database.ErrTableNotFound.Error())
 	})
 
-	t.Run("List", func(t *testing.T) {
-		tx, cleanup := newTestDB(t)
-		defer cleanup()
-
-		tables := tx.ListTables()
-		require.Len(t, tables, 0)
-
-		err := tx.CreateTable("foo", nil)
-		require.NoError(t, err)
-
-		err = tx.CreateTable("bar", nil)
-		require.NoError(t, err)
-
-		err = tx.CreateTable("baz", nil)
-		require.NoError(t, err)
-
-		tables = tx.ListTables()
-		// The returned slice should be lexicographically ordered.
-		exp := []string{"bar", "baz", "foo"}
-		require.Equal(t, exp, tables)
-	})
-
 	t.Run("Rename", func(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
@@ -154,7 +131,7 @@ func TestTxTable(t *testing.T) {
 		// The field constraints should be the same.
 		info, err := tb.Info()
 		require.NoError(t, err)
-		require.Equal(t, ti, info)
+		require.Equal(t, ti.FieldConstraints, info.FieldConstraints)
 
 		// Check that the indexes have been updated as well.
 		idxs, err := tx.ListIndexes()

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -39,6 +39,10 @@ func TestTxTable(t *testing.T) {
 		// Creating a table that already exists should fail.
 		err = tx.CreateTable("test", nil)
 		require.EqualError(t, err, database.ErrTableAlreadyExists.Error())
+
+		// Creating a table that starts with __genji_ should fail.
+		err = tx.CreateTable("__genji_foo", nil)
+		require.Error(t, err)
 	})
 
 	t.Run("Create and rollback", func(t *testing.T) {

--- a/sql/query/alter_test.go
+++ b/sql/query/alter_test.go
@@ -38,4 +38,8 @@ func TestAlterTable(t *testing.T) {
 	err = document.ToJSON(&buf, d)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"name": "John Doe", "age": 99}`, buf.String())
+
+	// Renaming a read-only table should fail
+	err = db.Exec("ALTER TABLE __genji_tables RENAME TO bar")
+	require.Error(t, err)
 }

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -20,6 +20,7 @@ func TestDeleteStmt(t *testing.T) {
 		{"No cond", `DELETE FROM test`, false, "", nil},
 		{"With cond", "DELETE FROM test WHERE b = 'bar1'", false, `{"d": "foo3", "b": "bar2", "e": "bar3"}`, nil},
 		{"Table not found", "DELETE FROM foo WHERE b = 'bar1'", true, "", nil},
+		{"Read-only table", "DELETE FROM __genji_tables", true, "", nil},
 	}
 
 	for _, test := range tests {

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/genjidb/genji"
 	"github.com/genjidb/genji/database"
+	"github.com/genjidb/genji/document"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,11 +29,20 @@ func TestDropTable(t *testing.T) {
 	require.Error(t, err)
 
 	// Assert that only the table `test1` has been dropped.
+	res, err := db.Query("SELECT table_name FROM __genji_tables")
+	require.NoError(t, err)
 	var tables []string
-	err = db.View(func(tx *genji.Tx) error {
-		tables = tx.ListTables()
+	err = res.Iterate(func(d document.Document) error {
+		v, err := d.GetByField("table_name")
+		if err != nil {
+			return err
+		}
+		tables = append(tables, v.V.(string))
 		return nil
 	})
+	require.NoError(t, err)
+	require.NoError(t, res.Close())
+
 	require.Len(t, tables, 2)
 
 	// Dropping a read-only table should fail.

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -34,6 +34,10 @@ func TestDropTable(t *testing.T) {
 		return nil
 	})
 	require.Len(t, tables, 2)
+
+	// Dropping a read-only table should fail.
+	err = db.Exec("DROP TABLE __genji_tables")
+	require.Error(t, err)
 }
 
 func TestDropIndex(t *testing.T) {

--- a/sql/query/insert_test.go
+++ b/sql/query/insert_test.go
@@ -37,6 +37,7 @@ func TestInsertStmt(t *testing.T) {
 		{"Documents / strings", `INSERT INTO test VALUES {'a': 'a', b: 2.3}`, false, `{"pk()":1,"a":"a","b":2.3}`, nil},
 		{"Documents / double quotes", `INSERT INTO test VALUES {"a": "b"}`, false, `{"pk()":1,"a":"b"}`, nil},
 		{"Documents / with reference to other fields", `INSERT INTO test VALUES {a: 400, b: a * 4}`, false, `{"pk()":1,"a":400,"b":1600}`, nil},
+		{"Read-only tables", `INSERT INTO __genji_tables VALUES {a: 400, b: a * 4}`, true, ``, nil},
 	}
 
 	for _, test := range tests {

--- a/sql/query/reindex_test.go
+++ b/sql/query/reindex_test.go
@@ -19,6 +19,7 @@ func TestReIndex(t *testing.T) {
 		{"ReIndex table", `REINDEX test2`, []string{"idx_test2_a", "idx_test2_b"}, false},
 		{"ReIndex index", `REINDEX idx_test1_a`, []string{"idx_test1_a"}, false},
 		{"ReIndex unknown", `REINDEX doesntexist`, []string{}, true},
+		{"ReIndex read-only", `REINDEX __genji_tables`, []string{}, true},
 	}
 
 	for _, test := range tests {

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -18,8 +18,8 @@ func TestUpdateStmt(t *testing.T) {
 		expected string
 		params   []interface{}
 	}{
-		// Test without any clause.
 		{"No clause", `UPDATE test`, true, "", nil},
+		{"Read-only table", `UPDATE __genji_tables SET a = 1`, true, "", nil},
 
 		// SET tests.
 		{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},


### PR DESCRIPTION
This PR allows running SELECT queries against the `__genji_tables` table, which manages the `tableInfoStore`.