### PR TITLE
Table suggestion after FROM keyword

### DIFF
--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -320,7 +320,6 @@ func (sh *Shell) getAllTables() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	defer res.Close()
 
 	err = res.Iterate(func(d document.Document) error {

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -238,11 +238,9 @@ func (sh *Shell) runCommand(in string) error {
 		}
 
 		return runIndexesCmd(db, cmd)
-	case ".help":
-		return runHelpCmd()
 	}
 
-	return fmt.Errorf("unknown command %q. Enter \".help\" for help.", cmd)
+	return fmt.Errorf("unknown command %q", cmd)
 }
 
 func (sh *Shell) runQuery(q string) error {

--- a/sql/parser/delete.go
+++ b/sql/parser/delete.go
@@ -20,7 +20,9 @@ func (p *Parser) parseDeleteStatement() (*planner.Tree, error) {
 	// Parse table name
 	cfg.TableName, err = p.parseIdent()
 	if err != nil {
-		return nil, newParseError("", []string{"table_name"}, scanner.Pos{})
+		pErr := err.(*ParseError)
+		pErr.Expected = []string{"table_name"}
+		return nil, pErr
 	}
 
 	// Parse condition: "WHERE EXPR".

--- a/sql/parser/delete.go
+++ b/sql/parser/delete.go
@@ -20,7 +20,7 @@ func (p *Parser) parseDeleteStatement() (*planner.Tree, error) {
 	// Parse table name
 	cfg.TableName, err = p.parseIdent()
 	if err != nil {
-		return nil, err
+		return nil, newParseError("", []string{"table_name"}, scanner.Pos{})
 	}
 
 	// Parse condition: "WHERE EXPR".

--- a/sql/parser/drop.go
+++ b/sql/parser/drop.go
@@ -39,7 +39,9 @@ func (p *Parser) parseDropTableStatement() (query.DropTableStmt, error) {
 	// Parse table name
 	stmt.TableName, err = p.parseIdent()
 	if err != nil {
-		return stmt, newParseError("", []string{"table_name"}, scanner.Pos{})
+		pErr := err.(*ParseError)
+		pErr.Expected = []string{"table_name"}
+		return stmt, pErr
 	}
 
 	return stmt, nil

--- a/sql/parser/drop.go
+++ b/sql/parser/drop.go
@@ -39,7 +39,7 @@ func (p *Parser) parseDropTableStatement() (query.DropTableStmt, error) {
 	// Parse table name
 	stmt.TableName, err = p.parseIdent()
 	if err != nil {
-		return stmt, err
+		return stmt, newParseError("", []string{"table_name"}, scanner.Pos{})
 	}
 
 	return stmt, nil

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -124,10 +124,12 @@ func (p *Parser) parseFrom() (string, bool, error) {
 	// Parse table name
 	ident, err := p.parseIdent()
 	if err != nil {
-		return ident, true,  newParseError("", []string{"table"}, scanner.Pos{})
+		pErr := err.(*ParseError)
+		pErr.Expected = []string{"table_name"}
+		return ident, true, pErr
 	}
 
-	return ident, true,  err
+	return ident, true,  nil
 }
 
 func (p *Parser) parseOrderBy() (expr.FieldSelector, scanner.Token, error) {

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -124,7 +124,7 @@ func (p *Parser) parseFrom() (string, bool, error) {
 	// Parse table name
 	ident, err := p.parseIdent()
 	if err != nil {
-		return ident, true,  newParseError("", []string{"table_name"}, scanner.Pos{})
+		return ident, true,  newParseError("", []string{"table"}, scanner.Pos{})
 	}
 
 	return ident, true,  err

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-
 	"github.com/genjidb/genji/sql/planner"
 	"github.com/genjidb/genji/sql/query/expr"
 	"github.com/genjidb/genji/sql/scanner"
@@ -124,7 +123,11 @@ func (p *Parser) parseFrom() (string, bool, error) {
 
 	// Parse table name
 	ident, err := p.parseIdent()
-	return ident, true, err
+	if err != nil {
+		return ident, true,  newParseError("", []string{"table_name"}, scanner.Pos{})
+	}
+
+	return ident, true,  err
 }
 
 func (p *Parser) parseOrderBy() (expr.FieldSelector, scanner.Token, error) {


### PR DESCRIPTION
This PR fixes the #143 .
Tables are listed after `FROM` keyword in `SELECT and DELETE` statements.
Added to `DROP TABLE` statement too.
If there is no tables the word `table_name` is displayed:
```
genji> SELECT * FROM table_name
```