### PR TITLE
Add .help command.

### DIFF
--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -2,10 +2,18 @@ package shell
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/genjidb/genji"
 	"github.com/genjidb/genji/document"
 )
+
+var commands = map[string]string{
+	".tables":               "\t\tList names of tables.",
+	".exit":                 "\t\t\tExit this program.",
+	".indexes [table_name]": "\tDisplay all indexes or the indexes of the given table name.",
+	".help":                 "\t\t\tList all commands.",
+}
 
 func runTablesCmd(db *genji.DB, cmd []string) error {
 	if len(cmd) > 1 {
@@ -79,8 +87,22 @@ func runIndexesCmd(db *genji.DB, in []string) error {
 	case 2:
 		// If the input is ".indexes <tableName>"
 		return displayTableIndex(db, in[1])
-
 	}
 
 	return fmt.Errorf("usage: .indexes [tablename]")
+}
+
+// runHelpCmd display all available dot commands.
+func runHelpCmd() error {
+	var keys []string
+	for k := range commands {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Printf("%s %s\n", k, commands[k])
+	}
+
+	return nil
 }

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -88,6 +88,7 @@ func Run(opts *Options) error {
 		fmt.Printf("On-disk database using Badger engine at path %s.\n", opts.DBPath)
 	}
 
+	fmt.Println("Enter \".help\" for usage hints.")
 	history, err := sh.loadHistory()
 	if err != nil {
 		return err
@@ -237,9 +238,11 @@ func (sh *Shell) runCommand(in string) error {
 		}
 
 		return runIndexesCmd(db, cmd)
+	case ".help":
+		return runHelpCmd()
 	}
 
-	return fmt.Errorf("unknown command %q", cmd)
+	return fmt.Errorf("unknown command %q. Enter \".help\" for help.", cmd)
 }
 
 func (sh *Shell) runQuery(q string) error {


### PR DESCRIPTION
This PR fixes #158. 
The `.help` command list all the available dot command.
A message `Enter ".help" for usage hints` is displayed at genji launch. 
```
On-disk database using BoltDB engine at path my.db.
**.**
genji> .help
.exit 			        Exit genji program
.help 			        List all available dot commands
.indexes [table_name] 	Display all indexes of the database or that the given table_name
.tables 		                 List names of tables
````