### PR TITLE
Fix list index implementation

### DIFF
--- a/engine/badgerengine/engine.go
+++ b/engine/badgerengine/engine.go
@@ -36,6 +36,7 @@ func (e *Engine) Begin(writable bool) (engine.Transaction, error) {
 	tx := e.DB.NewTransaction(writable)
 
 	return &Transaction{
+		ng:       e,
 		tx:       tx,
 		writable: writable,
 	}, nil
@@ -48,6 +49,7 @@ func (e *Engine) Close() error {
 
 // A Transaction uses Badger's transactions.
 type Transaction struct {
+	ng        *Engine
 	tx        *badger.Txn
 	writable  bool
 	discarded bool
@@ -110,6 +112,7 @@ func (t *Transaction) GetStore(name []byte) (engine.Store, error) {
 	pkey := buildStorePrefixKey(name)
 
 	return &Store{
+		ng:       t.ng,
 		tx:       t.tx,
 		prefix:   pkey,
 		writable: t.writable,

--- a/engine/badgerengine/store.go
+++ b/engine/badgerengine/store.go
@@ -110,13 +110,22 @@ func (s *Store) NextSequence() (uint64, error) {
 		return 0, engine.ErrTransactionReadOnly
 	}
 
+	// this is an ineficient way of generating sequences.
+	// use a bigger lease in the future.
 	seq, err := s.ng.DB.GetSequence([]byte(s.name), 1)
 	if err != nil {
 		return 0, err
 	}
 	defer seq.Release()
 
-	return seq.Next()
+	nb, err := seq.Next()
+	if err != nil {
+		return 0, err
+	}
+
+	// the first number in a sequence is always zero
+	// but Genji expects the first to be 1.
+	return nb + 1, nil
 }
 
 // NewIterator uses a Badger iterator with default options.

--- a/engine/badgerengine/store.go
+++ b/engine/badgerengine/store.go
@@ -103,14 +103,13 @@ func (s *Store) Truncate() error {
 	return nil
 }
 
-// NextSequence returns a monotonically increasing integer across
-// the engine.
+// NextSequence returns a monotonically increasing integer.
 func (s *Store) NextSequence() (uint64, error) {
 	if !s.writable {
 		return 0, engine.ErrTransactionReadOnly
 	}
 
-	// this is an ineficient way of generating sequences.
+	// TODO: this is an ineficient way of generating sequences.
 	// use a bigger lease in the future.
 	seq, err := s.ng.DB.GetSequence([]byte(s.name), 1)
 	if err != nil {
@@ -123,7 +122,7 @@ func (s *Store) NextSequence() (uint64, error) {
 		return 0, err
 	}
 
-	// the first number in a sequence is always zero
+	// the first number in a Badger sequence is always zero
 	// but Genji expects the first to be 1.
 	return nb + 1, nil
 }

--- a/engine/boltengine/store.go
+++ b/engine/boltengine/store.go
@@ -62,6 +62,15 @@ func (s *Store) Truncate() error {
 	return err
 }
 
+// NextSequence returns a monotonically increasing integer.
+func (s *Store) NextSequence() (uint64, error) {
+	if !s.bucket.Writable() {
+		return 0, engine.ErrTransactionReadOnly
+	}
+
+	return s.bucket.NextSequence()
+}
+
 // NewIterator uses the bucket cursor.
 func (s *Store) NewIterator(cfg engine.IteratorConfig) engine.Iterator {
 	return &iterator{

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -67,6 +67,8 @@ type Store interface {
 	Truncate() error
 	// NewIterator creates an iterator with the given config.
 	NewIterator(IteratorConfig) Iterator
+	// NextSequence returns a monotonically increasing integer.
+	NextSequence() (uint64, error)
 }
 
 // IteratorConfig is used to configure an iterator upon creation.

--- a/engine/memoryengine/engine.go
+++ b/engine/memoryengine/engine.go
@@ -17,16 +17,17 @@ const btreeDegree = 12
 // Engine is a simple memory engine implementation that stores data in
 // an in-memory Btree. It allows multiple readers and one single writer.
 type Engine struct {
-	closed bool
-	stores map[string]*btree.BTree
-
-	mu sync.RWMutex
+	closed    bool
+	stores    map[string]*btree.BTree
+	sequences map[string]uint64
+	mu        sync.RWMutex
 }
 
 // NewEngine creates an in-memory engine.
 func NewEngine() *Engine {
 	return &Engine{
-		stores: make(map[string]*btree.BTree),
+		stores:    make(map[string]*btree.BTree),
+		sequences: make(map[string]uint64),
 	}
 }
 
@@ -124,7 +125,7 @@ func (tx *transaction) GetStore(name []byte) (engine.Store, error) {
 		return nil, engine.ErrStoreNotFound
 	}
 
-	return &storeTx{tx: tx, tr: tr}, nil
+	return &storeTx{tx: tx, tr: tr, name: string(name)}, nil
 }
 
 func (tx *transaction) CreateStore(name []byte) error {

--- a/index/index.go
+++ b/index/index.go
@@ -9,10 +9,8 @@ import (
 )
 
 const (
-	// StorePrefix is the prefix used to name the index store.
-	StorePrefix = "i" + string(separator)
-
-	separator byte = 0x1E
+	// storePrefix is the prefix used to name the index stores.
+	storePrefix = "i"
 )
 
 var valueTypes = []document.ValueType{
@@ -75,13 +73,10 @@ func NewUniqueIndex(tx engine.Transaction, idxName string) *UniqueIndex {
 func buildIndexName(name []byte, t document.ValueType) []byte {
 	var buf bytes.Buffer
 
-	// We can deterministically set the size of the buffer.
-	// The last 2 bytes are for the separator and the Type t.
-	buf.Grow(len(StorePrefix) + len(name) + 2)
+	buf.Grow(len(storePrefix) + len(name) + 1)
 
-	buf.WriteString(StorePrefix)
+	buf.WriteString(storePrefix)
 	buf.Write(name)
-	buf.WriteByte(separator)
 	buf.WriteByte(byte(t))
 
 	return buf.Bytes()

--- a/index/list.go
+++ b/index/list.go
@@ -36,7 +36,7 @@ func (idx *ListIndex) Set(v document.Value, k []byte) error {
 	if err != nil {
 		return err
 	}
-	buf = key.AppendUint64(buf, seq)
+	buf = key.AppendInt64(buf, int64(seq))
 
 	return st.Put(buf, k)
 }

--- a/key/encoding.go
+++ b/key/encoding.go
@@ -16,11 +16,6 @@ import (
 	"github.com/genjidb/genji/document"
 )
 
-// EncodeString takes a string and returns its binary representation.
-func EncodeString(buf []byte, x string) {
-	copy(buf, x)
-}
-
 // AppendBool takes a bool and returns its binary representation.
 func AppendBool(buf []byte, x bool) []byte {
 	if x {

--- a/key/encoding_test.go
+++ b/key/encoding_test.go
@@ -3,30 +3,32 @@ package key
 import (
 	"bytes"
 	"testing"
+	"time"
 
+	"github.com/genjidb/genji/document"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValueEncodeDecode(t *testing.T) {
 	tests := []struct {
-		name     string
-		expected interface{}
-		enc      func([]byte) []byte
-		dec      func([]byte) (interface{}, error)
+		name string
+		v    document.Value
 	}{
-		{"bool", true, func(buf []byte) []byte { return AppendBool(buf, true) }, func(buf []byte) (interface{}, error) { return DecodeBool(buf), nil }},
-		{"uint64", uint64(10), func(buf []byte) []byte { return AppendUint64(buf, 10) }, func(buf []byte) (interface{}, error) { return DecodeUint64(buf) }},
-		{"int64", int64(-10), func(buf []byte) []byte { return AppendInt64(buf, -10) }, func(buf []byte) (interface{}, error) { return DecodeInt64(buf) }},
-		{"float64", float64(-3.14), func(buf []byte) []byte { return AppendFloat64(buf, -3.14) }, func(buf []byte) (interface{}, error) { return DecodeFloat64(buf) }},
+		{"null", document.NewNullValue()},
+		{"bool", document.NewBoolValue(true)},
+		{"integer", document.NewIntegerValue(-10)},
+		{"double", document.NewDoubleValue(-3.14)},
+		{"text", document.NewTextValue("foo")},
+		{"blob", document.NewBlobValue([]byte("bar"))},
+		{"duration", document.NewDurationValue(10 * time.Second)},
 	}
 
 	for _, test := range tests {
-		var buf []byte
 		t.Run(test.name, func(t *testing.T) {
-			buf = test.enc(buf[:0])
-			actual, err := test.dec(buf)
+			b := AppendValue(nil, test.v)
+			got, err := DecodeValue(test.v.Type, b)
 			require.NoError(t, err)
-			require.Equal(t, test.expected, actual)
+			require.Equal(t, test.v, got)
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes #170 by changing how list indexes are implemented. Previously, each couple _value to index / key_ was stored in a store as following:

| store key | store value |
| - | - |
| `value to index`+`separator`+`key of the associated document` | nil |

This used to be valued as some point but this now has some obvious issues as the separator can be contained in both the value to index and the key of the document, making it impossible to determine where the separator is.

The new implementation uses a new method added to the engines called `NextSequence()`, which is responsible of returning a monotonically increasing integer.
This integer will be encoded and appended to every value to index, while the document key will be stored in the value of the store:

| store key | store value |
| - | - |
| `value to index`+`integer` |`key of the associated document` |


