### PR TITLE
Add primary key config to tableInfo

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -298,6 +298,16 @@ func (t *tableInfoStore) loadAllTableInfo(tx engine.Transaction) error {
 	t.tableInfos[tableInfoStoreName] = TableInfo{
 		storeName: []byte(tableInfoStoreName),
 		readOnly:  true,
+		FieldConstraints: []FieldConstraint{
+			{
+				Path: document.ValuePath{
+					document.ValuePathFragment{
+						FieldName: "table_name",
+					},
+				},
+				IsPrimaryKey: true,
+			},
+		},
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes how the `pk()` function works with `__genji_tables`.
It adds information about the primary key of that table, so that pk can pick it up correctly.

Before:
```sql
genji> create table foo;
genji> create table bar(a integer);
genji> SELECT pk(), * from __genji_tables;
json: error calling MarshalJSON for type document.jsonDocument: cannot decode buffer to uint64
``` 

After:
```sql
genji> create table foo;
genji> create table bar(a integer);
genji> SELECT pk(), * from __genji_tables;
{
  "pk()": "bar",
  "table_name": "bar",
  "store_id": "dF9LVloqBA==",
  "field_constraints": [
    {
      "path": [
        "a"
      ],
      "type": 16,
      "is_primary_key": false,
      "is_not_null": false
    }
  ],
  "read_only": false
}
{
  "pk()": "foo",
  "table_name": "foo",
  "store_id": "dF9LVlljTQ==",
  "field_constraints": [],
  "read_only": false
}
```