### PR TITLE
Fix node order

### DIFF
--- a/sql/parser/select_test.go
+++ b/sql/parser/select_test.go
@@ -84,92 +84,92 @@ func TestParserSelect(t *testing.T) {
 			false},
 		{"WithOrderBy", "SELECT * FROM test WHERE age = 10 ORDER BY a.b.c",
 			planner.NewTree(
-				planner.NewProjectionNode(
-					planner.NewSortNode(
+				planner.NewSortNode(
+					planner.NewProjectionNode(
 						planner.NewSelectionNode(
 							planner.NewTableInputNode("test"),
 							expr.Eq(expr.FieldSelector(parsePath(t, "age")), expr.IntegerValue(10)),
 						),
-						expr.FieldSelector(parsePath(t, "a.b.c")),
-						scanner.ASC,
+						[]planner.ResultField{planner.Wildcard{}},
+						"test",
 					),
-					[]planner.ResultField{planner.Wildcard{}},
-					"test",
+					expr.FieldSelector(parsePath(t, "a.b.c")),
+					scanner.ASC,
 				)),
 			false},
 		{"WithOrderBy ASC", "SELECT * FROM test WHERE age = 10 ORDER BY a.b.c ASC",
 			planner.NewTree(
-				planner.NewProjectionNode(
-					planner.NewSortNode(
+				planner.NewSortNode(
+					planner.NewProjectionNode(
 						planner.NewSelectionNode(
 							planner.NewTableInputNode("test"),
 							expr.Eq(expr.FieldSelector(parsePath(t, "age")), expr.IntegerValue(10)),
 						),
-						expr.FieldSelector(parsePath(t, "a.b.c")),
-						scanner.ASC,
+						[]planner.ResultField{planner.Wildcard{}},
+						"test",
 					),
-					[]planner.ResultField{planner.Wildcard{}},
-					"test",
+					expr.FieldSelector(parsePath(t, "a.b.c")),
+					scanner.ASC,
 				)),
 			false},
 		{"WithOrderBy DESC", "SELECT * FROM test WHERE age = 10 ORDER BY a.b.c DESC",
 			planner.NewTree(
-				planner.NewProjectionNode(
-					planner.NewSortNode(
+				planner.NewSortNode(
+					planner.NewProjectionNode(
 						planner.NewSelectionNode(
 							planner.NewTableInputNode("test"),
 							expr.Eq(expr.FieldSelector(parsePath(t, "age")), expr.IntegerValue(10)),
 						),
-						expr.FieldSelector(parsePath(t, "a.b.c")),
-						scanner.DESC,
+						[]planner.ResultField{planner.Wildcard{}},
+						"test",
 					),
-					[]planner.ResultField{planner.Wildcard{}},
-					"test",
+					expr.FieldSelector(parsePath(t, "a.b.c")),
+					scanner.DESC,
 				)),
 			false},
 		{"WithLimit", "SELECT * FROM test WHERE age = 10 LIMIT 20",
 			planner.NewTree(
-				planner.NewProjectionNode(
-					planner.NewLimitNode(
+				planner.NewLimitNode(
+					planner.NewProjectionNode(
 						planner.NewSelectionNode(
 							planner.NewTableInputNode("test"),
 							expr.Eq(expr.FieldSelector(parsePath(t, "age")), expr.IntegerValue(10)),
 						),
-						20,
+						[]planner.ResultField{planner.Wildcard{}},
+						"test",
 					),
-					[]planner.ResultField{planner.Wildcard{}},
-					"test",
+					20,
 				)),
 			false},
 		{"WithOffset", "SELECT * FROM test WHERE age = 10 OFFSET 20",
 			planner.NewTree(
-				planner.NewProjectionNode(
-					planner.NewOffsetNode(
+				planner.NewOffsetNode(
+					planner.NewProjectionNode(
 						planner.NewSelectionNode(
 							planner.NewTableInputNode("test"),
 							expr.Eq(expr.FieldSelector(parsePath(t, "age")), expr.IntegerValue(10)),
 						),
-						20,
+						[]planner.ResultField{planner.Wildcard{}},
+						"test",
 					),
-					[]planner.ResultField{planner.Wildcard{}},
-					"test",
+					20,
 				)),
 			false},
 		{"WithLimitThenOffset", "SELECT * FROM test WHERE age = 10 LIMIT 10 OFFSET 20",
 			planner.NewTree(
-				planner.NewProjectionNode(
-					planner.NewLimitNode(
-						planner.NewOffsetNode(
+				planner.NewLimitNode(
+					planner.NewOffsetNode(
+						planner.NewProjectionNode(
 							planner.NewSelectionNode(
 								planner.NewTableInputNode("test"),
 								expr.Eq(expr.FieldSelector(parsePath(t, "age")), expr.IntegerValue(10)),
 							),
-							20,
+							[]planner.ResultField{planner.Wildcard{}},
+							"test",
 						),
-						10,
+						20,
 					),
-					[]planner.ResultField{planner.Wildcard{}},
-					"test",
+					10,
 				)),
 			false},
 		{"WithOffsetThenLimit", "SELECT * FROM test WHERE age = 10 OFFSET 20 LIMIT 10", nil, true},

--- a/sql/planner/explain_test.go
+++ b/sql/planner/explain_test.go
@@ -23,7 +23,7 @@ func TestExplainStmt(t *testing.T) {
 		{"EXPLAIN SELECT a + 1 FROM test WHERE c IN [1 + 1, 2 + 2]", false, `"Table(test) -> σ(cond: c IN [2, 4]) -> ∏(a + 1)"`},
 		{"EXPLAIN SELECT a + 1 FROM test WHERE a > 10", false, `"Index(idx_a) -> ∏(a + 1)"`},
 		{"EXPLAIN SELECT a + 1 FROM test WHERE a > 10 AND b > 20 AND c > 30", false, `"Index(idx_b) -> σ(cond: c > 30) -> σ(cond: a > 10) -> ∏(a + 1)"`},
-		{"EXPLAIN SELECT a + 1 FROM test WHERE c > 30 ORDER BY a DESC LIMIT 10 OFFSET 20", false, `"Table(test) -> σ(cond: c > 30) -> Sort(a DESC) -> Offset(20) -> Limit(10) -> ∏(a + 1)"`},
+		{"EXPLAIN SELECT a + 1 FROM test WHERE c > 30 ORDER BY a DESC LIMIT 10 OFFSET 20", false, `"Table(test) -> σ(cond: c > 30) -> ∏(a + 1) -> Sort(a DESC) -> Offset(20) -> Limit(10)"`},
 		{"EXPLAIN UPDATE test SET a = 10", false, `"Table(test) -> Set(a = 10) -> Replace(test)"`},
 		{"EXPLAIN UPDATE test SET a = 10 WHERE c > 10", false, `"Table(test) -> σ(cond: c > 10) -> Set(a = 10) -> Replace(test)"`},
 		{"EXPLAIN UPDATE test SET a = 10 WHERE a > 10", false, `"Index(idx_a) -> Set(a = 10) -> Replace(test)"`},

--- a/sql/planner/projection.go
+++ b/sql/planner/projection.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document"
-	"github.com/genjidb/genji/sql/query"
 	"github.com/genjidb/genji/sql/query/expr"
 )
 
@@ -25,7 +24,6 @@ type ProjectionNode struct {
 	tx   *database.Transaction
 }
 
-var _ outputNode = (*ProjectionNode)(nil)
 var _ operationNode = (*ProjectionNode)(nil)
 
 // NewProjectionNode creates a ProjectionNode.
@@ -78,16 +76,6 @@ func (n *ProjectionNode) toStream(st document.Stream) (document.Stream, error) {
 
 		return &dm, nil
 	}), nil
-}
-
-func (n *ProjectionNode) toResult(st document.Stream) (res query.Result, err error) {
-	st, err = n.toStream(st)
-	if err != nil {
-		return
-	}
-
-	res.Stream = st
-	return
 }
 
 func (n *ProjectionNode) String() string {

--- a/sql/planner/projection.go
+++ b/sql/planner/projection.go
@@ -71,7 +71,7 @@ func (n *ProjectionNode) toStream(st document.Stream) (document.Stream, error) {
 	var dm documentMask
 	return st.Map(func(d document.Document) (document.Document, error) {
 		dm.info = n.info
-		dm.r = d
+		dm.d = d
 		dm.resultFields = n.Expressions
 
 		return &dm, nil
@@ -93,7 +93,7 @@ func (n *ProjectionNode) String() string {
 
 type documentMask struct {
 	info         *database.TableInfo
-	r            document.Document
+	d            document.Document
 	resultFields []ResultField
 }
 
@@ -102,7 +102,7 @@ var _ document.Document = documentMask{}
 func (r documentMask) GetByField(field string) (document.Value, error) {
 	for _, rf := range r.resultFields {
 		if rf.Name() == field || rf.Name() == "*" {
-			return r.r.GetByField(field)
+			return r.d.GetByField(field)
 		}
 	}
 
@@ -111,7 +111,7 @@ func (r documentMask) GetByField(field string) (document.Value, error) {
 
 func (r documentMask) Iterate(fn func(field string, value document.Value) error) error {
 	stack := expr.EvalStack{
-		Document: r.r,
+		Document: r.d,
 		Info:     r.info,
 	}
 

--- a/sql/planner/tree.go
+++ b/sql/planner/tree.go
@@ -81,7 +81,14 @@ func (t *Tree) execute() (query.Result, error) {
 		}
 	}
 
-	return t.Root.(outputNode).toResult(st)
+	st, err = t.Root.(operationNode).toStream(st)
+	if err != nil {
+		return query.Result{}, err
+	}
+
+	return query.Result{
+		Stream: st,
+	}, nil
 }
 
 func (t *Tree) String() string {
@@ -154,12 +161,6 @@ type operationNode interface {
 	Node
 
 	toStream(st document.Stream) (document.Stream, error)
-}
-
-type outputNode interface {
-	Node
-
-	toResult(st document.Stream) (query.Result, error)
 }
 
 type node struct {


### PR DESCRIPTION
This PR fixes the order of the nodes generated by the parser. Projections are supposed to happen before sorting and limit/offset.

```sql
EXPLAIN SELECT a + 1 FROM test WHERE c > 30 ORDER BY a DESC LIMIT 10 OFFSET 20
```

Before:
```
Table(test) -> σ(cond: c > 30) -> Sort(a DESC) -> Offset(20) -> Limit(10) -> ∏(a + 1)
```

After:
```
Table(test) -> σ(cond: c > 30) -> ∏(a + 1) -> Sort(a DESC) -> Offset(20) -> Limit(10)
```