### PR TITLE
Min Max aggregators

### DIFF
--- a/sql/query/expr/function.go
+++ b/sql/query/expr/function.go
@@ -22,6 +22,12 @@ var functions = map[string]func(args ...Expr) (Expr, error){
 		}
 		return &CountFunc{Expr: args[0]}, nil
 	},
+	"min": func(args ...Expr) (Expr, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("MIN() takes 1 argument")
+		}
+		return &MinFunc{Expr: args[0]}, nil
+	},
 }
 
 // GetFunc return a function expression by name.

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -76,6 +76,8 @@ func TestSelectStmt(t *testing.T) {
 		{"With count", "SELECT COUNT(k) FROM test", false, `[{"COUNT(k)": 3}]`, nil},
 		{"With count wildcard", "SELECT COUNT(*) FROM test", false, `[{"COUNT(*)": 3}]`, nil},
 		{"With multiple counts", "SELECT COUNT(k), COUNT(color) FROM test", false, `[{"COUNT(k)": 3, "COUNT(color)": 2}]`, nil},
+		{"With min", "SELECT MIN(k) FROM test", false, `[{"MIN(k)": 1}]`, nil},
+		{"With multiple mins", "SELECT MIN(color), MIN(weight) FROM test", false, `[{"MIN(color)": "blue", "MIN(weight)": 100}]`, nil},
 		{"With two non existing idents, =", "SELECT * FROM test WHERE z = y", false, `[]`, nil},
 		{"With two non existing idents, >", "SELECT * FROM test WHERE z > y", false, `[]`, nil},
 		{"With two non existing idents, !=", "SELECT * FROM test WHERE z != y", false, `[]`, nil},

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -78,6 +78,8 @@ func TestSelectStmt(t *testing.T) {
 		{"With multiple counts", "SELECT COUNT(k), COUNT(color) FROM test", false, `[{"COUNT(k)": 3, "COUNT(color)": 2}]`, nil},
 		{"With min", "SELECT MIN(k) FROM test", false, `[{"MIN(k)": 1}]`, nil},
 		{"With multiple mins", "SELECT MIN(color), MIN(weight) FROM test", false, `[{"MIN(color)": "blue", "MIN(weight)": 100}]`, nil},
+		{"With max", "SELECT MAX(k) FROM test", false, `[{"MAX(k)": 3}]`, nil},
+		{"With multiple maxs", "SELECT MAX(color), MAX(weight) FROM test", false, `[{"MAX(color)": "red", "MAX(weight)": 200}]`, nil},
 		{"With two non existing idents, =", "SELECT * FROM test WHERE z = y", false, `[]`, nil},
 		{"With two non existing idents, >", "SELECT * FROM test WHERE z > y", false, `[]`, nil},
 		{"With two non existing idents, !=", "SELECT * FROM test WHERE z != y", false, `[]`, nil},


### PR DESCRIPTION
This PR adds preliminary Min and Max aggregators. They work great with scalars but behavior with array and document values is kind of random. This will be fixed once the comparison support for these types will be added.
Fixes #165, #166 