### PR TITLE
Add typed indexes

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -2,12 +2,12 @@ package database
 
 import (
 	"bytes"
+	"encoding/binary"
 	"sync"
 
 	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/engine"
 	"github.com/genjidb/genji/index"
-	"github.com/genjidb/genji/key"
 )
 
 const storePrefix = 't'
@@ -202,7 +202,10 @@ func (t *tableInfoStore) Insert(tx *Transaction, tableName string, info *TableIn
 		if err != nil {
 			return err
 		}
-		info.storeName = key.AppendInt64([]byte{storePrefix}, int64(seq))
+		buf := make([]byte, binary.MaxVarintLen64+1)
+		buf[0] = storePrefix
+		n := binary.PutUvarint(buf[1:], seq)
+		info.storeName = buf[:n+1]
 	}
 
 	var buf bytes.Buffer

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -153,6 +153,7 @@ func TestIndexStore(t *testing.T) {
 			TableName: "test",
 			IndexName: "idx_test",
 			Unique:    true,
+			Type:      document.BoolValue,
 		}
 
 		err = idxs.Insert(cfg)

--- a/database/table.go
+++ b/database/table.go
@@ -253,7 +253,10 @@ func (t *Table) Indexes() (map[string]Index, error) {
 				return err
 			}
 
-			idx := index.NewIndex(t.tx.tx, opts.IndexName, index.Options{Unique: opts.Unique})
+			idx := index.NewIndex(t.tx.tx, opts.IndexName, index.Options{
+				Unique: opts.Unique,
+				Type:   opts.Type,
+			})
 
 			indexes[opts.Path.String()] = Index{
 				Index: idx,

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -285,6 +285,9 @@ func (tx *Transaction) ReIndex(indexName string) error {
 
 	return tb.Iterate(func(d document.Document) error {
 		v, err := idx.Opts.Path.GetValue(d)
+		if err == document.ErrFieldNotFound {
+			return nil
+		}
 		if err != nil {
 			return err
 		}

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -262,6 +262,30 @@ func TestTxReIndex(t *testing.T) {
 		require.Equal(t, database.ErrIndexNotFound, err)
 	})
 
+	t.Run("Should not fail if field not found", func(t *testing.T) {
+		tx, cleanup := newTestDB(t)
+		defer cleanup()
+
+		err := tx.CreateTable("test", nil)
+		require.NoError(t, err)
+		tb, err := tx.GetTable("test")
+		require.NoError(t, err)
+
+		_, err = tb.Insert(document.NewFieldBuffer().
+			Add("a", document.NewIntegerValue(1)),
+		)
+		require.NoError(t, err)
+
+		err = tx.CreateIndex(database.IndexConfig{
+			IndexName: "b",
+			TableName: "test",
+			Path:      parsePath(t, "b"),
+		})
+
+		err = tx.ReIndex("b")
+		require.NoError(t, err)
+	})
+
 	t.Run("Should reindex the right index", func(t *testing.T) {
 		tx, _, cleanup := newTestTableFn(t)
 		defer cleanup()


### PR DESCRIPTION
This PR introduces types in indexes. A typed index only accepts one type of values, this allows for several space efficient optimizations.