### PR TITLE
Add exit method to shell type

### DIFF
--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"log"
 	"os"
 
@@ -59,14 +57,4 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func fail(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, a...)
-	os.Exit(2)
-}
-
-func exitRecordUsage() {
-	flag.Usage()
-	os.Exit(2)
 }

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -122,15 +122,7 @@ func Run(opts *Options) error {
 	)
 
 	e.Run()
-
-	if sh.db != nil {
-		err = sh.db.Close()
-		if err != nil {
-			return err
-		}
-	}
-
-	return sh.dumpHistory()
+	return nil
 }
 
 func (sh *Shell) loadHistory() ([]string, error) {
@@ -242,7 +234,7 @@ func (sh *Shell) runCommand(in string) error {
 			return fmt.Errorf("usage: .exit")
 		}
 
-		os.Exit(0)
+		sh.exit()
 	case ".indexes":
 		db, err := sh.getDB()
 		if err != nil {
@@ -268,6 +260,22 @@ func (sh *Shell) runQuery(q string) error {
 
 	defer res.Close()
 	return document.IteratorToJSON(os.Stdout, res)
+}
+
+func (sh *Shell) exit() {
+	if sh.db != nil {
+		err := sh.db.Close()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+	}
+
+	err := sh.dumpHistory()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	}
+
+	os.Exit(0)
 }
 
 func (sh *Shell) getDB() (*genji.DB, error) {


### PR DESCRIPTION
Calling `.exit` was causing the shell to exit immediately, without flushing the history or closing the database. This PR adds a `exit` method that does exactly that.