### PR TITLE
Sell command can be ended by a semicolon #198

### DIFF
--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -238,6 +238,7 @@ func (sh *Shell) executeInput(in string) error {
 }
 
 func (sh *Shell) runCommand(in string) error {
+	in = strings.TrimSuffix(in, ";")
 	cmd := strings.Fields(in)
 	switch cmd[0] {
 	case ".help":


### PR DESCRIPTION
Fixes #198 

shell commands are to be allowed the suffix of semicolon.