### PR TITLE
Fix benchmarks for badgerengine

### DIFF
--- a/engine/enginetest/benchmark.go
+++ b/engine/enginetest/benchmark.go
@@ -49,6 +49,10 @@ func BenchmarkStoreScan(b *testing.B, builder Builder) {
 				it := st.NewIterator(engine.IteratorConfig{})
 				for it.Seek(nil); it.Valid(); it.Next() {
 				}
+				err := it.Close()
+				if err != nil {
+					require.NoError(b, err)
+				}
 			}
 			b.StopTimer()
 		})


### PR DESCRIPTION
Running `go test -bench Scan` in `engine/badgerengine` panics.
See the commit message for the details.
