### PR TITLE
Added replace rule for badgerengine in cmd/genji module

### DIFF
--- a/cmd/genji/go.mod
+++ b/cmd/genji/go.mod
@@ -7,9 +7,12 @@ require (
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/genjidb/genji v0.9.0
-	github.com/genjidb/genji/engine/badgerengine v0.8.0
+	github.com/genjidb/genji/engine/badgerengine v0.9.0
 	github.com/stretchr/testify v1.6.1
 	github.com/urfave/cli/v2 v2.2.0
 )
 
-replace github.com/genjidb/genji v0.9.0 => ../../
+replace (
+	github.com/genjidb/genji v0.9.0 => ../../
+	github.com/genjidb/genji/engine/badgerengine v0.9.0 => ../../engine/badgerengine
+)


### PR DESCRIPTION
Replace in `go.mod` works only for the main module.
