### PR TITLE
Add support for context.Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ func main() {
     defer res.Close()
 
     // Iterate over the results
-    err = res.Iterate(context.Background(), func(d document.Document) error {
+    err = res.Iterate(func(d document.Document) error {
         // When querying an explicit list of fields, you can use the Scan function to scan them
         // in order. Note that the types don't have to match exactly the types stored in the table
         // as long as they are compatible.

--- a/README.md
+++ b/README.md
@@ -73,10 +73,8 @@ import (
 )
 
 func main() {
-    ctx := context.Background()
-
     // Create a database instance, here we'll store everything on-disk using the BoltDB engine
-    db, err := genji.Open(ctx, "my.db")
+    db, err := genji.Open(context.Background(), "my.db")
     if err != nil {
         log.Fatal(err)
     }
@@ -84,16 +82,16 @@ func main() {
     defer db.Close()
 
     // Create a table. Schemas are optional, you don't need to specify one if not needed
-    err = db.Exec(ctx, "CREATE TABLE user")
+    err = db.Exec("CREATE TABLE user")
 
     // Create an index
-    err = db.Exec(ctx, "CREATE INDEX idx_user_name ON test (name)")
+    err = db.Exec("CREATE INDEX idx_user_name ON test (name)")
 
     // Insert some data
-    err = db.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "Foo1", 15)
+    err = db.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "Foo1", 15)
 
     // Supported values can go from simple integers to richer data types like lists or documents
-    err = db.Exec(ctx, `
+    err = db.Exec(`
     INSERT INTO user (id, name, age, address, friends)
     VALUES (
         11,
@@ -123,15 +121,15 @@ func main() {
     u.Address.City = "Lyon"
     u.Address.ZipCode = "69001"
 
-    err = db.Exec(ctx, `INSERT INTO user VALUES ?`, &u)
+    err = db.Exec(`INSERT INTO user VALUES ?`, &u)
 
     // Query some documents
-    res, err := db.Query(ctx, "SELECT id, name, age, address FROM user WHERE age >= ?", 18)
+    res, err := db.Query("SELECT id, name, age, address FROM user WHERE age >= ?", 18)
     // always close the result when you're done with it
     defer res.Close()
 
     // Iterate over the results
-    err = res.Iterate(ctx, func(d document.Document) error {
+    err = res.Iterate(context.Background(), func(d document.Document) error {
         // When querying an explicit list of fields, you can use the Scan function to scan them
         // in order. Note that the types don't have to match exactly the types stored in the table
         // as long as they are compatible.
@@ -207,8 +205,7 @@ import (
 )
 
 func main() {
-    ctx := context.Background()
-    db, err := genji.Open(ctx, "my.db")
+    db, err := genji.Open(context.Background(), "my.db")
     defer db.Close()
 }
 ```
@@ -224,8 +221,7 @@ import (
 )
 
 func main() {
-    ctx := context.Background()
-    db, err := genji.Open(ctx, ":memory:")
+    db, err := genji.Open(context.Background(), ":memory:")
     if err != nil {
         log.Fatal(err)
     }
@@ -252,8 +248,6 @@ import (
 )
 
 func main() {
-    ctx := context.Background()
-
     // Create a badger engine
     ng, err := badgerengine.NewEngine(badger.DefaultOptions("mydb"))
     if err != nil {
@@ -261,7 +255,7 @@ func main() {
     }
 
     // Pass it to genji
-    db, err := genji.New(ctx, ng)
+    db, err := genji.New(context.Background(), ng)
     if err != nil {
         log.Fatal(err)
     }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ There are two ways of using Genji, either by using Genji's API or by using the [
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -72,15 +73,15 @@ import (
 )
 
 func main() {
+    ctx := context.Background()
+
     // Create a database instance, here we'll store everything on-disk using the BoltDB engine
-    db, err := genji.Open("my.db")
+    db, err := genji.Open(ctx, "my.db")
     if err != nil {
         log.Fatal(err)
     }
     // Don't forget to close the database when you're done
     defer db.Close()
-
-    ctx := context.Background()
 
     // Create a table. Schemas are optional, you don't need to specify one if not needed
     err = db.Exec(ctx, "CREATE TABLE user")
@@ -130,7 +131,7 @@ func main() {
     defer res.Close()
 
     // Iterate over the results
-    err = res.Iterate(func(d document.Document) error {
+    err = res.Iterate(ctx, func(d document.Document) error {
         // When querying an explicit list of fields, you can use the Scan function to scan them
         // in order. Note that the types don't have to match exactly the types stored in the table
         // as long as they are compatible.
@@ -199,13 +200,15 @@ Genji currently supports storing data in [BoltDB](https://github.com/etcd-io/bbo
 
 ```go
 import (
+    "context"
     "log"
 
     "github.com/genjidb/genji"
 )
 
 func main() {
-    db, err := genji.Open("my.db")
+    ctx := context.Background()
+    db, err := genji.Open(ctx, "my.db")
     defer db.Close()
 }
 ```
@@ -214,13 +217,15 @@ func main() {
 
 ```go
 import (
+    "context"
     "log"
 
     "github.com/genjidb/genji"
 )
 
 func main() {
-    db, err := genji.Open(":memory:")
+    ctx := context.Background()
+    db, err := genji.Open(ctx, ":memory:")
     if err != nil {
         log.Fatal(err)
     }
@@ -238,6 +243,7 @@ go get github.com/genjidb/genji/engine/badgerengine
 
 ```go
 import (
+    "context"
     "log"
 
     "github.com/genjidb/genji"
@@ -246,6 +252,8 @@ import (
 )
 
 func main() {
+    ctx := context.Background()
+
     // Create a badger engine
     ng, err := badgerengine.NewEngine(badger.DefaultOptions("mydb"))
     if err != nil {
@@ -253,7 +261,7 @@ func main() {
     }
 
     // Pass it to genji
-    db, err := genji.New(ng)
+    db, err := genji.New(ctx, ng)
     if err != nil {
         log.Fatal(err)
     }

--- a/cmd/genji/insert.go
+++ b/cmd/genji/insert.go
@@ -66,7 +66,7 @@ func executeInsertCommand(ctx context.Context, db *genji.DB, table string, r io.
 				return err
 			}
 
-			if err := db.Exec(ctx, q, &fb); err != nil {
+			if err := db.Exec(q, &fb); err != nil {
 				return err
 			}
 		}
@@ -89,7 +89,7 @@ func executeInsertCommand(ctx context.Context, db *genji.DB, table string, r io.
 				return err
 			}
 
-			if err := db.Exec(ctx, q, &fb); err != nil {
+			if err := db.Exec(q, &fb); err != nil {
 				return err
 			}
 		}
@@ -144,7 +144,7 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 	defer db.Close()
 
 	if createTable {
-		err := db.Exec(ctx, "CREATE TABLE "+table)
+		err := db.Exec("CREATE TABLE " + table)
 		if err != nil {
 			return err
 		}

--- a/cmd/genji/insert.go
+++ b/cmd/genji/insert.go
@@ -38,7 +38,7 @@ func skipSpaces(r *bufio.Reader) (byte, error) {
 	return c, nil
 }
 
-func executeInsertCommand(ctx context.Context, db *genji.DB, table string, r io.Reader) error {
+func executeInsertCommand(db *genji.DB, table string, r io.Reader) error {
 	q := fmt.Sprintf("INSERT INTO %s VALUES ?", table)
 	rd := bufio.NewReader(r)
 	var c byte
@@ -153,7 +153,7 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 	fi, _ := os.Stdin.Stat()
 	m := fi.Mode()
 	if (m & os.ModeNamedPipe) != 0 {
-		return executeInsertCommand(ctx, db, table, os.Stdin)
+		return executeInsertCommand(db, table, os.Stdin)
 	}
 
 	if len(args) == 0 {
@@ -161,7 +161,7 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 	}
 
 	for _, arg := range args {
-		if err := executeInsertCommand(ctx, db, table, strings.NewReader(arg)); err != nil {
+		if err := executeInsertCommand(db, table, strings.NewReader(arg)); err != nil {
 			return err
 		}
 	}

--- a/cmd/genji/insert.go
+++ b/cmd/genji/insert.go
@@ -137,7 +137,7 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 		return err
 	}
 
-	db, err := genji.New(ng)
+	db, err := genji.New(ctx, ng)
 	if err != nil {
 		return err
 	}

--- a/cmd/genji/insert_test.go
+++ b/cmd/genji/insert_test.go
@@ -30,12 +30,11 @@ func TestExecuteInsertCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, `CREATE TABLE foo`)
+			err = db.Exec(`CREATE TABLE foo`)
 			require.NoError(t, err)
 			err = executeInsertCommand(ctx, db, "foo", strings.NewReader(tt.data))
 			if tt.fails {
@@ -44,7 +43,7 @@ func TestExecuteInsertCommand(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			res, err := db.Query(ctx, "SELECT * FROM foo")
+			res, err := db.Query("SELECT * FROM foo")
 			defer res.Close()
 			require.NoError(t, err)
 
@@ -57,8 +56,6 @@ func TestExecuteInsertCommand(t *testing.T) {
 	}
 
 	t.Run(`Json Array`, func(t *testing.T) {
-		ctx := context.Background()
-
 		const jsonArray = `
 	[
 		{"Name": "Ed", "Text": "Knock knock."},
@@ -73,15 +70,16 @@ func TestExecuteInsertCommand(t *testing.T) {
 			`{"Name": "Sam", "Text": "Go fmt who?"}`,
 			`{"Name": "Ed", "Text": "Go fmt yourself!"}`}
 
+		ctx := context.Background()
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, `CREATE TABLE foo`)
+		err = db.Exec(`CREATE TABLE foo`)
 		require.NoError(t, err)
 		err = executeInsertCommand(ctx, db, "foo", strings.NewReader(jsonArray))
 		require.NoError(t, err)
-		res, err := db.Query(ctx, "SELECT * FROM foo")
+		res, err := db.Query("SELECT * FROM foo")
 		defer res.Close()
 		require.NoError(t, err)
 
@@ -96,8 +94,6 @@ func TestExecuteInsertCommand(t *testing.T) {
 	})
 
 	t.Run(`Json Stream`, func(t *testing.T) {
-		ctx := context.Background()
-
 		const jsonStream = `
 		{"Name": "Ed", "Text": "Knock knock."}
 		{"Name": "Sam", "Text": "Who's there?"}
@@ -110,17 +106,18 @@ func TestExecuteInsertCommand(t *testing.T) {
 			`{"Name": "Sam", "Text": "Go fmt who?"}`,
 			`{"Name": "Ed", "Text": "Go fmt yourself!"}`}
 
+		ctx := context.Background()
 		db, err := genji.Open(ctx, ":memory:")
 		defer db.Close()
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `CREATE TABLE foo`)
+		err = db.Exec(`CREATE TABLE foo`)
 		require.NoError(t, err)
 
 		err = executeInsertCommand(ctx, db, "foo", strings.NewReader(jsonStream))
 		require.NoError(t, err)
 
-		res, err := db.Query(ctx, "SELECT * FROM foo")
+		res, err := db.Query("SELECT * FROM foo")
 		defer res.Close()
 		require.NoError(t, err)
 

--- a/cmd/genji/insert_test.go
+++ b/cmd/genji/insert_test.go
@@ -29,14 +29,13 @@ func TestExecuteInsertCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
 			err = db.Exec(`CREATE TABLE foo`)
 			require.NoError(t, err)
-			err = executeInsertCommand(ctx, db, "foo", strings.NewReader(tt.data))
+			err = executeInsertCommand(db, "foo", strings.NewReader(tt.data))
 			if tt.fails {
 				require.Error(t, err)
 				return
@@ -48,7 +47,7 @@ func TestExecuteInsertCommand(t *testing.T) {
 			require.NoError(t, err)
 
 			var buf bytes.Buffer
-			err = document.IteratorToJSON(ctx, &buf, res)
+			err = document.IteratorToJSON(&buf, res)
 			require.NoError(t, err)
 			require.JSONEq(t, tt.want, buf.String())
 
@@ -70,21 +69,20 @@ func TestExecuteInsertCommand(t *testing.T) {
 			`{"Name": "Sam", "Text": "Go fmt who?"}`,
 			`{"Name": "Ed", "Text": "Go fmt yourself!"}`}
 
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
 		err = db.Exec(`CREATE TABLE foo`)
 		require.NoError(t, err)
-		err = executeInsertCommand(ctx, db, "foo", strings.NewReader(jsonArray))
+		err = executeInsertCommand(db, "foo", strings.NewReader(jsonArray))
 		require.NoError(t, err)
 		res, err := db.Query("SELECT * FROM foo")
 		defer res.Close()
 		require.NoError(t, err)
 
 		i := 0
-		_ = res.Iterate(ctx, func(d document.Document) error {
+		_ = res.Iterate(func(d document.Document) error {
 			data, err := document.MarshalJSON(d)
 			require.NoError(t, err)
 			require.JSONEq(t, jsonStreamResult[i], string(data))
@@ -106,15 +104,14 @@ func TestExecuteInsertCommand(t *testing.T) {
 			`{"Name": "Sam", "Text": "Go fmt who?"}`,
 			`{"Name": "Ed", "Text": "Go fmt yourself!"}`}
 
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		defer db.Close()
 		require.NoError(t, err)
 
 		err = db.Exec(`CREATE TABLE foo`)
 		require.NoError(t, err)
 
-		err = executeInsertCommand(ctx, db, "foo", strings.NewReader(jsonStream))
+		err = executeInsertCommand(db, "foo", strings.NewReader(jsonStream))
 		require.NoError(t, err)
 
 		res, err := db.Query("SELECT * FROM foo")
@@ -122,7 +119,7 @@ func TestExecuteInsertCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		i := 0
-		_ = res.Iterate(ctx, func(d document.Document) error {
+		_ = res.Iterate(func(d document.Document) error {
 			data, err := document.MarshalJSON(d)
 			require.NoError(t, err)
 			require.JSONEq(t, jsonStreamResult[i], string(data))
@@ -130,7 +127,7 @@ func TestExecuteInsertCommand(t *testing.T) {
 			return nil
 		})
 
-		wantCount, err := res.Count(ctx)
+		wantCount, err := res.Count()
 		require.NoError(t, err)
 		require.Equal(t, wantCount, i)
 	})

--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -112,7 +113,7 @@ $ curl https://api.github.com/repos/genjidb/genji/issues | genji insert --db my.
 			engine = "badger"
 		}
 
-		return shell.Run(&shell.Options{
+		return shell.Run(context.Background(), &shell.Options{
 			Engine: engine,
 			DBPath: dbpath,
 		})

--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -113,8 +112,7 @@ $ curl https://api.github.com/repos/genjidb/genji/issues | genji insert --db my.
 			engine = "badger"
 		}
 
-		ctx := context.Background()
-		return shell.Run(ctx, &shell.Options{
+		return shell.Run(c.Context, &shell.Options{
 			Engine: engine,
 			DBPath: dbpath,
 		})

--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -113,7 +113,8 @@ $ curl https://api.github.com/repos/genjidb/genji/issues | genji insert --db my.
 			engine = "badger"
 		}
 
-		return shell.Run(context.Background(), &shell.Options{
+		ctx := context.Background()
+		return shell.Run(ctx, &shell.Options{
 			Engine: engine,
 			DBPath: dbpath,
 		})

--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -31,7 +31,7 @@ func runTablesCmd(ctx context.Context, db *genji.DB, cmd []string) error {
 		return fmt.Errorf("usage: .tables")
 	}
 
-	res, err := db.Query(ctx, "SELECT table_name FROM __genji_tables")
+	res, err := db.Query("SELECT table_name FROM __genji_tables")
 	if err != nil {
 		return err
 	}
@@ -51,17 +51,15 @@ func runTablesCmd(ctx context.Context, db *genji.DB, cmd []string) error {
 // displayTableIndex prints all indexes that the given table contains.
 func displayTableIndex(db *genji.DB, tableName string) error {
 	return db.View(func(tx *genji.Tx) error {
-		ctx := context.Background()
-		_, err := tx.QueryDocument(ctx, "SELECT table_name FROM __genji_tables WHERE table_name = ?", tableName)
+		_, err := tx.QueryDocument("SELECT table_name FROM __genji_tables WHERE table_name = ?", tableName)
 		if err != nil {
 			if err == database.ErrDocumentNotFound {
 				return database.ErrTableNotFound
 			}
-
 			return err
 		}
 
-		res, err := tx.Query(ctx, "SELECT * FROM __genji_indexes WHERE table_name = ?", tableName)
+		res, err := tx.Query("SELECT * FROM __genji_indexes WHERE table_name = ?", tableName)
 		if err != nil {
 			return err
 		}
@@ -83,7 +81,7 @@ func displayTableIndex(db *genji.DB, tableName string) error {
 
 // displayAllIndexes shows all indexes that the database contains.
 func displayAllIndexes(ctx context.Context, db *genji.DB) error {
-	res, err := db.Query(ctx, "SELECT * FROM __genji_indexes")
+	res, err := db.Query("SELECT * FROM __genji_indexes")
 	if err != nil {
 		return err
 	}
@@ -231,7 +229,7 @@ func dumpTable(ctx context.Context, tx *genji.Tx, tableName string, w io.Writer)
 	}
 
 	q := fmt.Sprintf("SELECT * FROM %s", t.Name())
-	res, err := tx.Query(ctx, q)
+	res, err := tx.Query(q)
 	if err != nil {
 		return err
 	}
@@ -261,7 +259,7 @@ func dumpTable(ctx context.Context, tx *genji.Tx, tableName string, w io.Writer)
 
 // runDumpCmd dumps the given tables if provided, otherwise it dumps the whole database.
 func runDumpCmd(ctx context.Context, db *genji.DB, tables []string, w io.Writer) error {
-	tx, err := db.Begin(ctx, false)
+	tx, err := db.Begin(false)
 	if err != nil {
 		return err
 	}
@@ -299,7 +297,7 @@ func runDumpCmd(ctx context.Context, db *genji.DB, tables []string, w io.Writer)
 
 	// tables slice argument is empty.
 	// Dump database content.
-	res, err := tx.Query(ctx, "SELECT table_name FROM __genji_tables")
+	res, err := tx.Query("SELECT table_name FROM __genji_tables")
 	if err != nil {
 		_, err = fmt.Fprintln(w, "ROLLBACK;")
 		return err

--- a/cmd/genji/shell/command_test.go
+++ b/cmd/genji/shell/command_test.go
@@ -31,7 +31,6 @@ func TestRunTablesCmd(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
@@ -69,14 +68,13 @@ func TestIndexesCmd(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 						CREATE INDEX idx_a ON test (a);
 						CREATE INDEX idx_b ON test (b);
 						CREATE INDEX idx_c ON test (c);
@@ -108,7 +106,6 @@ func TestRunDumpCmd(t *testing.T) {
 		testFn := func(withIndexes, withConstraints bool) func(t *testing.T) {
 			return func(t *testing.T) {
 				ctx := context.Background()
-
 				db, err := genji.Open(ctx, ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
@@ -120,23 +117,23 @@ func TestRunDumpCmd(t *testing.T) {
 				ci := "COMMIT;\n"
 				if withConstraints {
 					q := fmt.Sprintf("CREATE TABLE test (\n  a %s\n);\n", tt.fieldConstraint)
-					err := db.Exec(ctx, q)
+					err := db.Exec(q)
 					require.NoError(t, err)
 					bwant.WriteString(q)
 				} else {
 					q := `CREATE TABLE test;`
-					err = db.Exec(ctx, q)
+					err = db.Exec(q)
 					require.NoError(t, err)
 					q = fmt.Sprintf("%s\n", q)
 					bwant.WriteString(q)
 				}
 
 				if withIndexes {
-					err = db.Exec(ctx, `
+					err = db.Exec(`
 						CREATE INDEX idx_a ON test (a);
 					`)
 					require.NoError(t, err)
-					err = db.View(ctx, func(tx *genji.Tx) error {
+					err = db.View(func(tx *genji.Tx) error {
 						// indexes is unordered, we cannot guess the order.
 						// we have to test only one index creation.
 						indexes, err := tx.ListIndexes(ctx)
@@ -151,7 +148,7 @@ func TestRunDumpCmd(t *testing.T) {
 					require.NoError(t, err)
 
 				}
-				err = db.Exec(ctx, tt.query, tt.params...)
+				err = db.Exec(tt.query, tt.params...)
 				if tt.fails {
 					require.Error(t, err)
 					return

--- a/cmd/genji/shell/command_test.go
+++ b/cmd/genji/shell/command_test.go
@@ -30,8 +30,7 @@ func TestRunTablesCmd(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -67,8 +66,7 @@ func TestIndexesCmd(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -80,7 +78,7 @@ func TestIndexesCmd(t *testing.T) {
 						CREATE INDEX idx_c ON test (c);
 					`)
 			require.NoError(t, err)
-			if err := runIndexesCmd(ctx, db, test.in); (err != nil) != test.wantErr {
+			if err := runIndexesCmd(db, test.in); (err != nil) != test.wantErr {
 				require.Errorf(t, err, "", test.wantErr)
 			}
 		})
@@ -105,8 +103,7 @@ func TestRunDumpCmd(t *testing.T) {
 
 		testFn := func(withIndexes, withConstraints bool) func(t *testing.T) {
 			return func(t *testing.T) {
-				ctx := context.Background()
-				db, err := genji.Open(ctx, ":memory:")
+				db, err := genji.Open(context.Background(), ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
 
@@ -136,7 +133,7 @@ func TestRunDumpCmd(t *testing.T) {
 					err = db.View(func(tx *genji.Tx) error {
 						// indexes is unordered, we cannot guess the order.
 						// we have to test only one index creation.
-						indexes, err := tx.ListIndexes(ctx)
+						indexes, err := tx.ListIndexes(tx.Context)
 						require.NoError(t, err)
 						for _, index := range indexes {
 							info := fmt.Sprintf("CREATE INDEX %s ON %s (%s);\n", index.IndexName, index.TableName,
@@ -158,7 +155,7 @@ func TestRunDumpCmd(t *testing.T) {
 				bwant.WriteString(tt.want)
 
 				var buf bytes.Buffer
-				err = runDumpCmd(ctx, db, []string{`test`}, &buf)
+				err = runDumpCmd(db, []string{`test`}, &buf)
 				require.NoError(t, err)
 				bwant.WriteString(ci)
 				require.Equal(t, bwant.String(), buf.String())

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -289,7 +289,7 @@ func (sh *Shell) runCommand(ctx context.Context, in string) error {
 			return err
 		}
 
-		return runTablesCmd(ctx, db, cmd)
+		return runTablesCmd(db, cmd)
 	case ".exit":
 		if len(cmd) > 1 {
 			return fmt.Errorf("usage: .exit")
@@ -301,14 +301,14 @@ func (sh *Shell) runCommand(ctx context.Context, in string) error {
 		if err != nil {
 			return err
 		}
-		return runIndexesCmd(ctx, db, cmd)
+		return runIndexesCmd(db, cmd)
 	case ".dump":
 		db, err := sh.getDB(ctx)
 		if err != nil {
 			return err
 		}
 
-		return runDumpCmd(ctx, db, cmd[1:], os.Stdout)
+		return runDumpCmd(db, cmd[1:], os.Stdout)
 	default:
 		return displaySuggestions(in)
 	}
@@ -332,7 +332,7 @@ func (sh *Shell) runQuery(ctx context.Context, q string) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
-	return res.Iterate(ctx, func(d document.Document) error {
+	return res.Iterate(func(d document.Document) error {
 		return enc.Encode(d)
 	})
 }
@@ -444,7 +444,7 @@ func (sh *Shell) getAllTables(ctx context.Context) ([]string, error) {
 	}
 	defer res.Close()
 
-	err = res.Iterate(ctx, func(d document.Document) error {
+	err = res.Iterate(func(d document.Document) error {
 		var tableName string
 		err = document.Scan(d, &tableName)
 		if err != nil {

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -322,7 +322,7 @@ func (sh *Shell) runQuery(ctx context.Context, q string) error {
 		return err
 	}
 
-	res, err := db.Query(ctx, q)
+	res, err := db.Query(q)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func (sh *Shell) getAllIndexes(ctx context.Context) ([]string, error) {
 	}
 
 	var listName []string
-	err = db.View(ctx, func(tx *genji.Tx) error {
+	err = db.View(func(tx *genji.Tx) error {
 		indexes, err := tx.ListIndexes(ctx)
 		if err != nil {
 			return err
@@ -438,7 +438,7 @@ func (sh *Shell) getAllIndexes(ctx context.Context) ([]string, error) {
 func (sh *Shell) getAllTables(ctx context.Context) ([]string, error) {
 	var tables []string
 	db, _ := sh.getDB(ctx)
-	res, err := db.Query(ctx, "SELECT table_name FROM __genji_tables")
+	res, err := db.Query("SELECT table_name FROM __genji_tables")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -148,8 +148,8 @@ func Run(ctx context.Context, opts *Options) error {
 	}
 
 	e := prompt.New(
-		sh.execute,
-		sh.completer,
+		sh.execute(ctx),
+		sh.completer(ctx),
 		promptOpts...,
 	)
 
@@ -232,9 +232,13 @@ func (sh *Shell) dumpHistory() error {
 	return w.Flush()
 }
 
-func (sh *Shell) execute(in string) {
-	ctx := context.Background()
+func (sh *Shell) execute(ctx context.Context) prompt.Executor {
+	return func(in string) {
+		sh.executeContext(ctx, in)
+	}
+}
 
+func (sh *Shell) executeContext(ctx context.Context, in string) {
 	sh.history = append(sh.history, in)
 
 	err := sh.executeInput(ctx, in)
@@ -458,9 +462,13 @@ func (sh *Shell) getAllTables(ctx context.Context) ([]string, error) {
 	return tables, nil
 }
 
-func (sh *Shell) completer(in prompt.Document) []prompt.Suggest {
-	ctx := context.Background()
+func (sh *Shell) completer(ctx context.Context) prompt.Completer {
+	return func(in prompt.Document) []prompt.Suggest {
+		return sh.completerContext(ctx, in)
+	}
+}
 
+func (sh *Shell) completerContext(ctx context.Context, in prompt.Document) []prompt.Suggest {
 	if strings.HasPrefix(in.Text, ".") {
 		return prompt.FilterHasPrefix(sh.cmdSuggestions, in.Text, true)
 	}

--- a/database/config.go
+++ b/database/config.go
@@ -287,10 +287,7 @@ func (t *tableInfoStore) loadAllTableInfo(ctx context.Context, tx engine.Transac
 
 	t.tableInfos = make(map[string]TableInfo)
 	var b []byte
-	if err := it.Seek(ctx, nil); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, nil); it.Valid(); it.Next(ctx) {
 		itm := it.Item()
 		b, err = itm.ValueCopy(b)
 		if err != nil {
@@ -304,10 +301,9 @@ func (t *tableInfoStore) loadAllTableInfo(ctx context.Context, tx engine.Transac
 		}
 
 		t.tableInfos[string(itm.Key())] = ti
-
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	t.tableInfos[tableInfoStoreName] = TableInfo{
@@ -527,10 +523,7 @@ func (t *indexStore) ListAll(ctx context.Context) ([]*IndexConfig, error) {
 	var idxList []*IndexConfig
 	var buf []byte
 	var err error
-	if err := it.Seek(ctx, nil); err != nil {
-		return nil, err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, nil); it.Valid(); it.Next(ctx) {
 		item := it.Item()
 		buf, err = item.ValueCopy(buf)
 		if err != nil {
@@ -544,10 +537,9 @@ func (t *indexStore) ListAll(ctx context.Context) ([]*IndexConfig, error) {
 		}
 
 		idxList = append(idxList, &opts)
-
-		if err := it.Next(ctx); err != nil {
-			return nil, err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
 	}
 
 	return idxList, nil

--- a/database/database.go
+++ b/database/database.go
@@ -2,8 +2,8 @@
 package database
 
 import (
-	"errors"
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 

--- a/database/table_test.go
+++ b/database/table_test.go
@@ -593,7 +593,7 @@ func TestTableReIndex(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		err := tb.ReIndex(ctx, )
+		err := tb.ReIndex(ctx)
 		require.NoError(t, err)
 	})
 
@@ -645,7 +645,7 @@ func TestTableReIndex(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = tb1.ReIndex(ctx, )
+		err = tb1.ReIndex(ctx)
 		require.NoError(t, err)
 
 		countIndexElems := func(idx *database.Index) int {
@@ -683,7 +683,7 @@ func TestTableIndexes(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		m, err := tb.Indexes(ctx, )
+		m, err := tb.Indexes(ctx)
 		require.NoError(t, err)
 		require.Empty(t, m)
 	})
@@ -722,7 +722,7 @@ func TestTableIndexes(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m, err := tb.Indexes(ctx, )
+		m, err := tb.Indexes(ctx)
 		require.NoError(t, err)
 		require.Len(t, m, 2)
 		idx1a, ok := m["a"]

--- a/database/table_test.go
+++ b/database/table_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -22,11 +23,13 @@ func parsePath(t testing.TB, str string) document.ValuePath {
 }
 
 func newTestTable(t testing.TB) (*database.Table, func()) {
+	ctx := context.Background()
+
 	tx, fn := newTestDB(t)
 
-	err := tx.CreateTable("test", nil)
+	err := tx.CreateTable(ctx, "test", nil)
 	require.NoError(t, err)
-	tb, err := tx.GetTable("test")
+	tb, err := tx.GetTable(ctx, "test")
 	require.NoError(t, err)
 
 	return tb, fn
@@ -40,12 +43,14 @@ func newDocument() *document.FieldBuffer {
 
 // TestTableIterate verifies Iterate behaviour.
 func TestTableIterate(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should not fail with no documents", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
 		i := 0
-		err := tb.Iterate(func(d document.Document) error {
+		err := tb.Iterate(ctx, func(d document.Document) error {
 			i++
 			return nil
 		})
@@ -58,12 +63,12 @@ func TestTableIterate(t *testing.T) {
 		defer cleanup()
 
 		for i := 0; i < 10; i++ {
-			_, err := tb.Insert(newDocument())
+			_, err := tb.Insert(ctx, newDocument())
 			require.NoError(t, err)
 		}
 
 		m := make(map[string]int)
-		err := tb.Iterate(func(d document.Document) error {
+		err := tb.Iterate(ctx, func(d document.Document) error {
 			m[string(d.(document.Keyer).Key())]++
 			return nil
 		})
@@ -79,12 +84,12 @@ func TestTableIterate(t *testing.T) {
 		defer cleanup()
 
 		for i := 0; i < 10; i++ {
-			_, err := tb.Insert(newDocument())
+			_, err := tb.Insert(ctx, newDocument())
 			require.NoError(t, err)
 		}
 
 		i := 0
-		err := tb.Iterate(func(_ document.Document) error {
+		err := tb.Iterate(ctx, func(_ document.Document) error {
 			i++
 			if i >= 5 {
 				return errors.New("some error")
@@ -98,11 +103,13 @@ func TestTableIterate(t *testing.T) {
 
 // TestTableGetDocument verifies GetDocument behaviour.
 func TestTableGetDocument(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should fail if not found", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		r, err := tb.GetDocument([]byte("id"))
+		r, err := tb.GetDocument(ctx, []byte("id"))
 		require.Equal(t, database.ErrDocumentNotFound, err)
 		require.Nil(t, r)
 	})
@@ -117,13 +124,13 @@ func TestTableGetDocument(t *testing.T) {
 		doc1.Add("fieldc", vc)
 		doc2 := newDocument()
 
-		key1, err := tb.Insert(doc1)
+		key1, err := tb.Insert(ctx, doc1)
 		require.NoError(t, err)
-		_, err = tb.Insert(doc2)
+		_, err = tb.Insert(ctx, doc2)
 		require.NoError(t, err)
 
 		// fetch doc1 and make sure it returns the right one
-		res, err := tb.GetDocument(key1)
+		res, err := tb.GetDocument(ctx, key1)
 		require.NoError(t, err)
 		fc, err := res.GetByField("fieldc")
 		require.NoError(t, err)
@@ -133,16 +140,18 @@ func TestTableGetDocument(t *testing.T) {
 
 // TestTableInsert verifies Insert behaviour.
 func TestTableInsert(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should generate a key by default", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
 		doc := newDocument()
-		key1, err := tb.Insert(doc)
+		key1, err := tb.Insert(ctx, doc)
 		require.NoError(t, err)
 		require.NotEmpty(t, key1)
 
-		key2, err := tb.Insert(doc)
+		key2, err := tb.Insert(ctx, doc)
 		require.NoError(t, err)
 		require.NotEmpty(t, key2)
 
@@ -152,20 +161,20 @@ func TestTableInsert(t *testing.T) {
 	t.Run("Should generate the right docid on existing databases", func(t *testing.T) {
 		ng := memoryengine.NewEngine()
 
-		db, err := database.New(ng, database.Options{Codec: msgpack.NewCodec()})
+		db, err := database.New(ctx, ng, database.Options{Codec: msgpack.NewCodec()})
 		require.NoError(t, err)
 
 		insertDoc := func(db *database.Database) []byte {
-			tx, err := db.Begin(true)
+			tx, err := db.Begin(ctx, true)
 			require.NoError(t, err)
 
-			_ = tx.CreateTable("test", &database.TableInfo{})
+			_ = tx.CreateTable(ctx, "test", &database.TableInfo{})
 
-			tb, err := tx.GetTable("test")
+			tb, err := tx.GetTable(ctx, "test")
 			require.NoError(t, err)
 
 			doc := newDocument()
-			key, err := tb.Insert(doc)
+			key, err := tb.Insert(ctx, doc)
 			require.NoError(t, err)
 			require.NotEmpty(t, key)
 
@@ -179,7 +188,7 @@ func TestTableInsert(t *testing.T) {
 		require.NoError(t, err)
 
 		// create new database object
-		db, err = database.New(ng, database.Options{Codec: msgpack.NewCodec()})
+		db, err = database.New(ctx, ng, database.Options{Codec: msgpack.NewCodec()})
 		require.NoError(t, err)
 
 		key2 := insertDoc(db)
@@ -197,13 +206,13 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableInfo{
+		err := tx.CreateTable(ctx, "test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{Path: parsePath(t, "foo.a[1]"), Type: document.IntegerValue, IsPrimaryKey: true},
 			},
 		})
 		require.NoError(t, err)
-		tb, err := tx.GetTable("test")
+		tb, err := tx.GetTable(ctx, "test")
 		require.NoError(t, err)
 
 		var doc document.FieldBuffer
@@ -211,16 +220,16 @@ func TestTableInsert(t *testing.T) {
 		require.NoError(t, err)
 
 		// insert
-		k, err := tb.Insert(doc)
+		k, err := tb.Insert(ctx, doc)
 		require.NoError(t, err)
 		require.Equal(t, key.AppendInt64(nil, 10), k)
 
 		// make sure the document is fetchable using the returned key
-		_, err = tb.GetDocument(k)
+		_, err = tb.GetDocument(ctx, k)
 		require.NoError(t, err)
 
 		// insert again
-		k, err = tb.Insert(doc)
+		k, err = tb.Insert(ctx, doc)
 		require.Equal(t, database.ErrDuplicateDocument, err)
 	})
 
@@ -228,14 +237,14 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableInfo{
+		err := tx.CreateTable(ctx, "test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{Path: parsePath(t, "foo"), Type: document.ArrayValue},
 				{Path: parsePath(t, "foo[0]"), Type: document.IntegerValue},
 			},
 		})
 		require.NoError(t, err)
-		tb, err := tx.GetTable("test")
+		tb, err := tx.GetTable(ctx, "test")
 		require.NoError(t, err)
 
 		var doc document.FieldBuffer
@@ -243,10 +252,10 @@ func TestTableInsert(t *testing.T) {
 		require.NoError(t, err)
 
 		// insert
-		key, err := tb.Insert(doc)
+		key, err := tb.Insert(ctx, doc)
 		require.NoError(t, err)
 
-		d, err := tb.GetDocument(key)
+		d, err := tb.GetDocument(ctx, key)
 		require.NoError(t, err)
 
 		v, err := parsePath(t, "foo[0]").GetValue(d)
@@ -258,13 +267,13 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableInfo{
+		err := tx.CreateTable(ctx, "test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{Path: parsePath(t, "foo"), Type: document.IntegerValue, IsPrimaryKey: true},
 			},
 		})
 		require.NoError(t, err)
-		tb, err := tx.GetTable("test")
+		tb, err := tx.GetTable(ctx, "test")
 		require.NoError(t, err)
 
 		tests := [][]byte{
@@ -278,7 +287,7 @@ func TestTableInsert(t *testing.T) {
 				doc := document.NewFieldBuffer().
 					Add("foo", document.NewBlobValue(test))
 
-				_, err := tb.Insert(doc)
+				_, err := tb.Insert(ctx, doc)
 				require.Error(t, err)
 			})
 		}
@@ -288,17 +297,17 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", nil)
+		err := tx.CreateTable(ctx, "test", nil)
 		require.NoError(t, err)
 
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			IndexName: "idxFoo", TableName: "test", Path: parsePath(t, "foo"),
 		})
 		require.NoError(t, err)
-		idx, err := tx.GetIndex("idxFoo")
+		idx, err := tx.GetIndex(ctx, "idxFoo")
 		require.NoError(t, err)
 
-		tb, err := tx.GetTable("test")
+		tb, err := tx.GetTable(ctx, "test")
 		require.NoError(t, err)
 
 		// create one document with the foo field
@@ -309,13 +318,13 @@ func TestTableInsert(t *testing.T) {
 		// create one document without the foo field
 		doc2 := newDocument()
 
-		key1, err := tb.Insert(doc1)
+		key1, err := tb.Insert(ctx, doc1)
 		require.NoError(t, err)
-		key2, err := tb.Insert(doc2)
+		key2, err := tb.Insert(ctx, doc2)
 		require.NoError(t, err)
 
 		var count int
-		err = idx.AscendGreaterOrEqual(document.Value{}, func(val, k []byte, isEqual bool) error {
+		err = idx.AscendGreaterOrEqual(ctx, document.Value{}, func(val, k []byte, isEqual bool) error {
 			switch count {
 			case 0:
 				// key2, which doesn't countain the field must appear first in the next,
@@ -335,14 +344,14 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test", &database.TableInfo{
+		err := tx.CreateTable(ctx, "test", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{parsePath(t, "foo"), document.IntegerValue, false, false},
 				{parsePath(t, "bar"), document.IntegerValue, false, false},
 			},
 		})
 		require.NoError(t, err)
-		tb, err := tx.GetTable("test")
+		tb, err := tx.GetTable(ctx, "test")
 		require.NoError(t, err)
 
 		doc := document.NewFieldBuffer().
@@ -351,11 +360,11 @@ func TestTableInsert(t *testing.T) {
 			Add("baz", document.NewTextValue("baaaaz"))
 
 		// insert
-		key, err := tb.Insert(doc)
+		key, err := tb.Insert(ctx, doc)
 		require.NoError(t, err)
 
 		// make sure the fields have been converted to the right types
-		d, err := tb.GetDocument(key)
+		d, err := tb.GetDocument(ctx, key)
 		require.NoError(t, err)
 		v, err := d.GetByField("foo")
 		require.NoError(t, err)
@@ -373,52 +382,52 @@ func TestTableInsert(t *testing.T) {
 		defer cleanup()
 
 		// no enforced type, not null
-		err := tx.CreateTable("test1", &database.TableInfo{
+		err := tx.CreateTable(ctx, "test1", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{parsePath(t, "foo"), 0, false, true},
 			},
 		})
 		require.NoError(t, err)
-		tb1, err := tx.GetTable("test1")
+		tb1, err := tx.GetTable(ctx, "test1")
 		require.NoError(t, err)
 
 		// enforced type, not null
-		err = tx.CreateTable("test2", &database.TableInfo{
+		err = tx.CreateTable(ctx, "test2", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{parsePath(t, "foo"), document.IntegerValue, false, true},
 			},
 		})
 		require.NoError(t, err)
-		tb2, err := tx.GetTable("test2")
+		tb2, err := tx.GetTable(ctx, "test2")
 		require.NoError(t, err)
 
 		// insert with empty foo field should fail
-		_, err = tb1.Insert(document.NewFieldBuffer().
+		_, err = tb1.Insert(ctx, document.NewFieldBuffer().
 			Add("bar", document.NewDoubleValue(1)))
 		require.Error(t, err)
 
 		// insert with null foo field should fail
-		_, err = tb1.Insert(document.NewFieldBuffer().
+		_, err = tb1.Insert(ctx, document.NewFieldBuffer().
 			Add("foo", document.NewNullValue()))
 		require.Error(t, err)
 
 		// otherwise it should work
-		_, err = tb1.Insert(document.NewFieldBuffer().
+		_, err = tb1.Insert(ctx, document.NewFieldBuffer().
 			Add("foo", document.NewDoubleValue(1)))
 		require.NoError(t, err)
 
 		// insert with empty foo field should fail
-		_, err = tb2.Insert(document.NewFieldBuffer().
+		_, err = tb2.Insert(ctx, document.NewFieldBuffer().
 			Add("bar", document.NewDoubleValue(1)))
 		require.Error(t, err)
 
 		// insert with null foo field should fail
-		_, err = tb2.Insert(document.NewFieldBuffer().
+		_, err = tb2.Insert(ctx, document.NewFieldBuffer().
 			Add("foo", document.NewNullValue()))
 		require.Error(t, err)
 
 		// otherwise it should work
-		_, err = tb2.Insert(document.NewFieldBuffer().
+		_, err = tb2.Insert(ctx, document.NewFieldBuffer().
 			Add("foo", document.NewDoubleValue(1)))
 		require.NoError(t, err)
 	})
@@ -427,20 +436,20 @@ func TestTableInsert(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test1", &database.TableInfo{
+		err := tx.CreateTable(ctx, "test1", &database.TableInfo{
 			FieldConstraints: []database.FieldConstraint{
 				{parsePath(t, "foo[1]"), 0, false, true},
 			},
 		})
 		require.NoError(t, err)
-		tb, err := tx.GetTable("test1")
+		tb, err := tx.GetTable(ctx, "test1")
 		require.NoError(t, err)
 
 		// insert table with only one value
-		_, err = tb.Insert(document.NewFieldBuffer().
+		_, err = tb.Insert(ctx, document.NewFieldBuffer().
 			Add("foo", document.NewArrayValue(document.NewValueBuffer().Append(document.NewIntegerValue(1)))))
 		require.Error(t, err)
-		_, err = tb.Insert(document.NewFieldBuffer().
+		_, err = tb.Insert(ctx, document.NewFieldBuffer().
 			Add("foo", document.NewArrayValue(document.NewValueBuffer().
 				Append(document.NewIntegerValue(1)).Append(document.NewIntegerValue(2)))))
 		require.NoError(t, err)
@@ -449,11 +458,13 @@ func TestTableInsert(t *testing.T) {
 
 // TestTableDelete verifies Delete behaviour.
 func TestTableDelete(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should fail if not found", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		err := tb.Delete([]byte("id"))
+		err := tb.Delete(ctx, []byte("id"))
 		require.Equal(t, database.ErrDocumentNotFound, err)
 	})
 
@@ -466,21 +477,21 @@ func TestTableDelete(t *testing.T) {
 		doc1.Add("fieldc", document.NewIntegerValue(40))
 		doc2 := newDocument()
 
-		key1, err := tb.Insert(doc1)
+		key1, err := tb.Insert(ctx, doc1)
 		require.NoError(t, err)
-		key2, err := tb.Insert(doc2)
+		key2, err := tb.Insert(ctx, doc2)
 		require.NoError(t, err)
 
 		// delete the document
-		err = tb.Delete([]byte(key1))
+		err = tb.Delete(ctx, []byte(key1))
 		require.NoError(t, err)
 
 		// try again, should fail
-		err = tb.Delete([]byte(key1))
+		err = tb.Delete(ctx, []byte(key1))
 		require.Equal(t, database.ErrDocumentNotFound, err)
 
 		// make sure it didn't also delete the other one
-		res, err := tb.GetDocument(key2)
+		res, err := tb.GetDocument(ctx, key2)
 		require.NoError(t, err)
 		_, err = res.GetByField("fieldc")
 		require.Error(t, err)
@@ -489,11 +500,13 @@ func TestTableDelete(t *testing.T) {
 
 // TestTableReplace verifies Replace behaviour.
 func TestTableReplace(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should fail if not found", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		err := tb.Replace([]byte("id"), newDocument())
+		err := tb.Replace(ctx, []byte("id"), newDocument())
 		require.Equal(t, database.ErrDocumentNotFound, err)
 	})
 
@@ -507,9 +520,9 @@ func TestTableReplace(t *testing.T) {
 			Add("fielda", document.NewTextValue("c")).
 			Add("fieldb", document.NewTextValue("d"))
 
-		key1, err := tb.Insert(doc1)
+		key1, err := tb.Insert(ctx, doc1)
 		require.NoError(t, err)
-		key2, err := tb.Insert(doc2)
+		key2, err := tb.Insert(ctx, doc2)
 		require.NoError(t, err)
 
 		// create a third document
@@ -518,18 +531,18 @@ func TestTableReplace(t *testing.T) {
 			Add("fieldb", document.NewTextValue("f"))
 
 		// replace doc1 with doc3
-		err = tb.Replace(key1, doc3)
+		err = tb.Replace(ctx, key1, doc3)
 		require.NoError(t, err)
 
 		// make sure it replaced it cordoctly
-		res, err := tb.GetDocument(key1)
+		res, err := tb.GetDocument(ctx, key1)
 		require.NoError(t, err)
 		f, err := res.GetByField("fielda")
 		require.NoError(t, err)
 		require.Equal(t, "e", f.V.(string))
 
 		// make sure it didn't also replace the other one
-		res, err = tb.GetDocument(key2)
+		res, err = tb.GetDocument(ctx, key2)
 		require.NoError(t, err)
 		f, err = res.GetByField("fielda")
 		require.NoError(t, err)
@@ -539,11 +552,13 @@ func TestTableReplace(t *testing.T) {
 
 // TestTableTruncate verifies Truncate behaviour.
 func TestTableTruncate(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should succeed if table empty", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		err := tb.Truncate()
+		err := tb.Truncate(ctx)
 		require.NoError(t, err)
 	})
 
@@ -555,15 +570,15 @@ func TestTableTruncate(t *testing.T) {
 		doc1 := newDocument()
 		doc2 := newDocument()
 
-		_, err := tb.Insert(doc1)
+		_, err := tb.Insert(ctx, doc1)
 		require.NoError(t, err)
-		_, err = tb.Insert(doc2)
-		require.NoError(t, err)
-
-		err = tb.Truncate()
+		_, err = tb.Insert(ctx, doc2)
 		require.NoError(t, err)
 
-		err = tb.Iterate(func(_ document.Document) error {
+		err = tb.Truncate(ctx)
+		require.NoError(t, err)
+
+		err = tb.Iterate(ctx, func(_ document.Document) error {
 			return errors.New("should not iterate")
 		})
 
@@ -572,11 +587,13 @@ func TestTableTruncate(t *testing.T) {
 }
 
 func TestTableReIndex(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should succeed if table has no index", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		err := tb.ReIndex()
+		err := tb.ReIndex(ctx, )
 		require.NoError(t, err)
 	})
 
@@ -584,56 +601,56 @@ func TestTableReIndex(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test1", nil)
+		err := tx.CreateTable(ctx, "test1", nil)
 		require.NoError(t, err)
-		err = tx.CreateTable("test2", nil)
+		err = tx.CreateTable(ctx, "test2", nil)
 		require.NoError(t, err)
-		tb1, err := tx.GetTable("test1")
+		tb1, err := tx.GetTable(ctx, "test1")
 		require.NoError(t, err)
-		tb2, err := tx.GetTable("test2")
+		tb2, err := tx.GetTable(ctx, "test2")
 		require.NoError(t, err)
 
 		for i := int64(0); i < 10; i++ {
 			doc := document.NewFieldBuffer().
 				Add("a", document.NewIntegerValue(i)).
 				Add("b", document.NewIntegerValue(i*10))
-			_, err = tb1.Insert(doc)
+			_, err = tb1.Insert(ctx, doc)
 			require.NoError(t, err)
-			_, err = tb2.Insert(doc)
+			_, err = tb2.Insert(ctx, doc)
 			require.NoError(t, err)
 		}
 
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			IndexName: "test1a",
 			TableName: "test1",
 			Path:      parsePath(t, "a"),
 		})
 		require.NoError(t, err)
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			IndexName: "test1b",
 			TableName: "test1",
 			Path:      parsePath(t, "b"),
 		})
 		require.NoError(t, err)
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			IndexName: "test2a",
 			TableName: "test2",
 			Path:      parsePath(t, "a"),
 		})
 		require.NoError(t, err)
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			IndexName: "test2b",
 			TableName: "test2",
 			Path:      parsePath(t, "b"),
 		})
 		require.NoError(t, err)
 
-		err = tb1.ReIndex()
+		err = tb1.ReIndex(ctx, )
 		require.NoError(t, err)
 
 		countIndexElems := func(idx *database.Index) int {
 			var i int
-			err = idx.AscendGreaterOrEqual(document.Value{Type: document.IntegerValue}, func(v, k []byte, isEqual bool) error {
+			err = idx.AscendGreaterOrEqual(ctx, document.Value{Type: document.IntegerValue}, func(v, k []byte, isEqual bool) error {
 				i++
 				return nil
 			})
@@ -641,30 +658,32 @@ func TestTableReIndex(t *testing.T) {
 			return i
 		}
 
-		idx, err := tx.GetIndex("test1a")
+		idx, err := tx.GetIndex(ctx, "test1a")
 		require.NoError(t, err)
 		require.Equal(t, 10, countIndexElems(idx))
 
-		idx, err = tx.GetIndex("test1b")
+		idx, err = tx.GetIndex(ctx, "test1b")
 		require.NoError(t, err)
 		require.Equal(t, 10, countIndexElems(idx))
 
-		idx, err = tx.GetIndex("test2a")
+		idx, err = tx.GetIndex(ctx, "test2a")
 		require.NoError(t, err)
 		require.Equal(t, 0, countIndexElems(idx))
 
-		idx, err = tx.GetIndex("test2b")
+		idx, err = tx.GetIndex(ctx, "test2b")
 		require.NoError(t, err)
 		require.Equal(t, 0, countIndexElems(idx))
 	})
 }
 
 func TestTableIndexes(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Should succeed if table has no indexes", func(t *testing.T) {
 		tb, cleanup := newTestTable(t)
 		defer cleanup()
 
-		m, err := tb.Indexes()
+		m, err := tb.Indexes(ctx, )
 		require.NoError(t, err)
 		require.Empty(t, m)
 	})
@@ -673,29 +692,29 @@ func TestTableIndexes(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
-		err := tx.CreateTable("test1", nil)
+		err := tx.CreateTable(ctx, "test1", nil)
 		require.NoError(t, err)
-		tb, err := tx.GetTable("test1")
-		require.NoError(t, err)
-
-		err = tx.CreateTable("test2", nil)
+		tb, err := tx.GetTable(ctx, "test1")
 		require.NoError(t, err)
 
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateTable(ctx, "test2", nil)
+		require.NoError(t, err)
+
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			Unique:    true,
 			IndexName: "idx1a",
 			TableName: "test1",
 			Path:      parsePath(t, "a"),
 		})
 		require.NoError(t, err)
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			Unique:    false,
 			IndexName: "idx1b",
 			TableName: "test1",
 			Path:      parsePath(t, "b"),
 		})
 		require.NoError(t, err)
-		err = tx.CreateIndex(database.IndexConfig{
+		err = tx.CreateIndex(ctx, database.IndexConfig{
 			Unique:    false,
 			IndexName: "ifx2a",
 			TableName: "test2",
@@ -703,7 +722,7 @@ func TestTableIndexes(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m, err := tb.Indexes()
+		m, err := tb.Indexes(ctx, )
 		require.NoError(t, err)
 		require.Len(t, m, 2)
 		idx1a, ok := m["a"]
@@ -717,6 +736,8 @@ func TestTableIndexes(t *testing.T) {
 
 // BenchmarkTableInsert benchmarks the Insert method with 1, 10, 1000 and 10000 successive insertions.
 func BenchmarkTableInsert(b *testing.B) {
+	ctx := context.Background()
+
 	for size := 1; size <= 10000; size *= 10 {
 		b.Run(fmt.Sprintf("%.05d", size), func(b *testing.B) {
 			var fb document.FieldBuffer
@@ -732,7 +753,7 @@ func BenchmarkTableInsert(b *testing.B) {
 
 				b.StartTimer()
 				for j := 0; j < size; j++ {
-					tb.Insert(&fb)
+					tb.Insert(ctx, &fb)
 				}
 				b.StopTimer()
 				cleanup()
@@ -743,6 +764,8 @@ func BenchmarkTableInsert(b *testing.B) {
 
 // BenchmarkTableScan benchmarks the Scan method with 1, 10, 1000 and 10000 successive insertions.
 func BenchmarkTableScan(b *testing.B) {
+	ctx := context.Background()
+
 	for size := 1; size <= 10000; size *= 10 {
 		b.Run(fmt.Sprintf("%.05d", size), func(b *testing.B) {
 			tb, cleanup := newTestTable(b)
@@ -755,13 +778,13 @@ func BenchmarkTableScan(b *testing.B) {
 			}
 
 			for i := 0; i < size; i++ {
-				_, err := tb.Insert(&fb)
+				_, err := tb.Insert(ctx, &fb)
 				require.NoError(b, err)
 			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				tb.Iterate(func(document.Document) error {
+				tb.Iterate(ctx, func(document.Document) error {
 					return nil
 				})
 			}

--- a/db.go
+++ b/db.go
@@ -21,8 +21,8 @@ func (db *DB) Close() error {
 
 // Begin starts a new transaction.
 // The returned transaction must be closed either by calling Rollback or Commit.
-func (db *DB) Begin(writable bool) (*Tx, error) {
-	tx, err := db.DB.Begin(writable)
+func (db *DB) Begin(ctx context.Context, writable bool) (*Tx, error) {
+	tx, err := db.DB.Begin(ctx, writable)
 	if err != nil {
 		return nil, err
 	}
@@ -33,8 +33,8 @@ func (db *DB) Begin(writable bool) (*Tx, error) {
 }
 
 // View starts a read only transaction, runs fn and automatically rolls it back.
-func (db *DB) View(fn func(tx *Tx) error) error {
-	tx, err := db.Begin(false)
+func (db *DB) View(ctx context.Context, fn func(tx *Tx) error) error {
+	tx, err := db.Begin(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -44,8 +44,8 @@ func (db *DB) View(fn func(tx *Tx) error) error {
 }
 
 // Update starts a read-write transaction, runs fn and automatically commits it.
-func (db *DB) Update(fn func(tx *Tx) error) error {
-	tx, err := db.Begin(true)
+func (db *DB) Update(ctx context.Context, fn func(tx *Tx) error) error {
+	tx, err := db.Begin(ctx, true)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (db *DB) QueryDocument(ctx context.Context, q string, args ...interface{}) 
 	}
 	defer res.Close()
 
-	r, err := res.First()
+	r, err := res.First(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (tx *Tx) QueryDocument(ctx context.Context, q string, args ...interface{}) 
 	}
 	defer res.Close()
 
-	r, err := res.First()
+	r, err := res.First(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/db.go
+++ b/db.go
@@ -19,7 +19,7 @@ type DB struct {
 func (db *DB) WithContext(ctx context.Context) *DB {
 	return &DB{
 		DB:      db.DB,
-		Context: ctx,
+		Context: context.Background(),
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -99,7 +99,7 @@ func (db *DB) QueryDocument(q string, args ...interface{}) (document.Document, e
 	}
 	defer res.Close()
 
-	r, err := res.First(db.Context)
+	r, err := res.First()
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (tx *Tx) QueryDocument(q string, args ...interface{}) (document.Document, e
 	}
 	defer res.Close()
 
-	r, err := res.First(tx.Context)
+	r, err := res.First()
 	if err != nil {
 		return nil, err
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -13,19 +13,19 @@ import (
 )
 
 func ExampleTx() {
-	db, err := genji.Open(":memory:")
+	ctx := context.Background()
+
+	db, err := genji.Open(ctx, ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-	tx, err := db.Begin(true)
+	tx, err := db.Begin(ctx, true)
 	if err != nil {
 		panic(err)
 	}
 	defer tx.Rollback()
-
-	ctx := context.Background()
 
 	err = tx.Exec(ctx, "CREATE TABLE IF NOT EXISTS user")
 	if err != nil {
@@ -71,13 +71,13 @@ func ExampleTx() {
 }
 
 func TestQueryDocument(t *testing.T) {
-	db, err := genji.Open(":memory:")
-	require.NoError(t, err)
-
-	tx, err := db.Begin(true)
-	require.NoError(t, err)
-
 	ctx := context.Background()
+
+	db, err := genji.Open(ctx, ":memory:")
+	require.NoError(t, err)
+
+	tx, err := db.Begin(ctx, true)
+	require.NoError(t, err)
 
 	err = tx.Exec(ctx, `
 			CREATE TABLE test;
@@ -96,7 +96,7 @@ func TestQueryDocument(t *testing.T) {
 		require.Equal(t, 1, a)
 		require.Equal(t, "foo", b)
 
-		tx, err := db.Begin(false)
+		tx, err := db.Begin(ctx, false)
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -113,7 +113,7 @@ func TestQueryDocument(t *testing.T) {
 		require.Equal(t, database.ErrDocumentNotFound, err)
 		require.Nil(t, r)
 
-		tx, err := db.Begin(false)
+		tx, err := db.Begin(ctx, false)
 		require.NoError(t, err)
 		defer tx.Rollback()
 		r, err = tx.QueryDocument(ctx, "SELECT * FROM test WHERE a > 100")

--- a/db_test.go
+++ b/db_test.go
@@ -13,31 +13,29 @@ import (
 )
 
 func ExampleTx() {
-	ctx := context.Background()
-
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-	tx, err := db.Begin(ctx, true)
+	tx, err := db.Begin(true)
 	if err != nil {
 		panic(err)
 	}
 	defer tx.Rollback()
 
-	err = tx.Exec(ctx, "CREATE TABLE IF NOT EXISTS user")
+	err = tx.Exec("CREATE TABLE IF NOT EXISTS user")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = tx.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
+	err = tx.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	d, err := tx.QueryDocument(ctx, "SELECT id, name, age FROM user WHERE name = ?", "foo")
+	d, err := tx.QueryDocument("SELECT id, name, age FROM user WHERE name = ?", "foo")
 	if err != nil {
 		panic(err)
 	}
@@ -71,15 +69,13 @@ func ExampleTx() {
 }
 
 func TestQueryDocument(t *testing.T) {
-	ctx := context.Background()
-
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	require.NoError(t, err)
 
-	tx, err := db.Begin(ctx, true)
+	tx, err := db.Begin(true)
 	require.NoError(t, err)
 
-	err = tx.Exec(ctx, `
+	err = tx.Exec(`
 			CREATE TABLE test;
 			INSERT INTO test (a, b) VALUES (1, 'foo'), (2, 'bar')
 		`)
@@ -90,17 +86,17 @@ func TestQueryDocument(t *testing.T) {
 		var a int
 		var b string
 
-		r, err := db.QueryDocument(ctx, "SELECT * FROM test")
+		r, err := db.QueryDocument("SELECT * FROM test")
 		err = document.Scan(r, &a, &b)
 		require.NoError(t, err)
 		require.Equal(t, 1, a)
 		require.Equal(t, "foo", b)
 
-		tx, err := db.Begin(ctx, false)
+		tx, err := db.Begin(false)
 		require.NoError(t, err)
 		defer tx.Rollback()
 
-		r, err = tx.QueryDocument(ctx, "SELECT * FROM test")
+		r, err = tx.QueryDocument("SELECT * FROM test")
 		require.NoError(t, err)
 		err = document.Scan(r, &a, &b)
 		require.NoError(t, err)
@@ -109,14 +105,14 @@ func TestQueryDocument(t *testing.T) {
 	})
 
 	t.Run("Should return an error if no document", func(t *testing.T) {
-		r, err := db.QueryDocument(ctx, "SELECT * FROM test WHERE a > 100")
+		r, err := db.QueryDocument("SELECT * FROM test WHERE a > 100")
 		require.Equal(t, database.ErrDocumentNotFound, err)
 		require.Nil(t, r)
 
-		tx, err := db.Begin(ctx, false)
+		tx, err := db.Begin(false)
 		require.NoError(t, err)
 		defer tx.Rollback()
-		r, err = tx.QueryDocument(ctx, "SELECT * FROM test WHERE a > 100")
+		r, err = tx.QueryDocument("SELECT * FROM test WHERE a > 100")
 		require.Equal(t, database.ErrDocumentNotFound, err)
 		require.Nil(t, r)
 	})

--- a/document/iterator_test.go
+++ b/document/iterator_test.go
@@ -15,24 +15,23 @@ import (
 
 func ExampleStream_First() {
 	ctx := context.Background()
-
 	db, err := genji.Open(ctx, ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-	err = db.Exec(ctx, "CREATE TABLE user")
+	err = db.Exec("CREATE TABLE user")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = db.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
+	err = db.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	result, err := db.Query(ctx, "SELECT id, name, age FROM user WHERE name = ?", "foo")
+	result, err := db.Query("SELECT id, name, age FROM user WHERE name = ?", "foo")
 	if err != nil {
 		panic(err)
 	}
@@ -70,20 +69,19 @@ func ExampleStream_Iterate() {
 	}
 
 	ctx := context.Background()
-
 	db, err := genji.Open(ctx, ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-	err = db.Exec(ctx, "CREATE TABLE IF NOT EXISTS user")
+	err = db.Exec("CREATE TABLE IF NOT EXISTS user")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for i := 1; i <= 10; i++ {
-		err = db.Exec(ctx, "INSERT INTO user VALUES ?", &User{
+		err = db.Exec("INSERT INTO user VALUES ?", &User{
 			ID:   int64(i),
 			Name: fmt.Sprintf("foo%d", i),
 			Age:  uint32(i * 10),
@@ -100,7 +98,7 @@ func ExampleStream_Iterate() {
 		}
 	}
 
-	result, err := db.Query(ctx, `SELECT id, name, age, address FROM user WHERE age >= 18`)
+	result, err := db.Query(`SELECT id, name, age, address FROM user WHERE age >= 18`)
 	if err != nil {
 		panic(err)
 	}
@@ -156,8 +154,6 @@ func ExampleStream_Iterate() {
 }
 
 func TestIteratorToJSONArray(t *testing.T) {
-	ctx := context.Background()
-
 	var docs []document.Document
 	for i := 0; i < 3; i++ {
 		fb := document.NewFieldBuffer()
@@ -168,7 +164,7 @@ func TestIteratorToJSONArray(t *testing.T) {
 
 	it := document.NewIterator(docs...)
 	var buf bytes.Buffer
-	err := document.IteratorToJSONArray(ctx, &buf, it)
+	err := document.IteratorToJSONArray(context.Background(), &buf, it)
 	require.NoError(t, err)
 	require.Equal(t, `[{"a": 0}, {"a": 1}, {"a": 2}]`, buf.String())
 }

--- a/document/iterator_test.go
+++ b/document/iterator_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func ExampleStream_First() {
-	db, err := genji.Open(":memory:")
+	ctx := context.Background()
+
+	db, err := genji.Open(ctx, ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
-
-	ctx := context.Background()
 
 	err = db.Exec(ctx, "CREATE TABLE user")
 	if err != nil {
@@ -38,7 +38,7 @@ func ExampleStream_First() {
 	}
 	defer result.Close()
 
-	d, err := result.First()
+	d, err := result.First(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -69,13 +69,13 @@ func ExampleStream_Iterate() {
 		}
 	}
 
-	db, err := genji.Open(":memory:")
+	ctx := context.Background()
+
+	db, err := genji.Open(ctx, ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
-
-	ctx := context.Background()
 
 	err = db.Exec(ctx, "CREATE TABLE IF NOT EXISTS user")
 	if err != nil {
@@ -106,7 +106,7 @@ func ExampleStream_Iterate() {
 	}
 	defer result.Close()
 
-	err = result.Iterate(func(d document.Document) error {
+	err = result.Iterate(ctx, func(d document.Document) error {
 		// Scan into a struct
 		var u User
 		err = document.StructScan(d, &u)
@@ -156,6 +156,8 @@ func ExampleStream_Iterate() {
 }
 
 func TestIteratorToJSONArray(t *testing.T) {
+	ctx := context.Background()
+
 	var docs []document.Document
 	for i := 0; i < 3; i++ {
 		fb := document.NewFieldBuffer()
@@ -166,7 +168,7 @@ func TestIteratorToJSONArray(t *testing.T) {
 
 	it := document.NewIterator(docs...)
 	var buf bytes.Buffer
-	err := document.IteratorToJSONArray(&buf, it)
+	err := document.IteratorToJSONArray(ctx, &buf, it)
 	require.NoError(t, err)
 	require.Equal(t, `[{"a": 0}, {"a": 1}, {"a": 2}]`, buf.String())
 }

--- a/document/iterator_test.go
+++ b/document/iterator_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func ExampleStream_First() {
-	ctx := context.Background()
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -37,7 +36,7 @@ func ExampleStream_First() {
 	}
 	defer result.Close()
 
-	d, err := result.First(ctx)
+	d, err := result.First()
 	if err != nil {
 		panic(err)
 	}
@@ -68,8 +67,7 @@ func ExampleStream_Iterate() {
 		}
 	}
 
-	ctx := context.Background()
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -104,7 +102,7 @@ func ExampleStream_Iterate() {
 	}
 	defer result.Close()
 
-	err = result.Iterate(ctx, func(d document.Document) error {
+	err = result.Iterate(func(d document.Document) error {
 		// Scan into a struct
 		var u User
 		err = document.StructScan(d, &u)
@@ -164,7 +162,7 @@ func TestIteratorToJSONArray(t *testing.T) {
 
 	it := document.NewIterator(docs...)
 	var buf bytes.Buffer
-	err := document.IteratorToJSONArray(context.Background(), &buf, it)
+	err := document.IteratorToJSONArray(&buf, it)
 	require.NoError(t, err)
 	require.Equal(t, `[{"a": 0}, {"a": 1}, {"a": 2}]`, buf.String())
 }

--- a/engine/badgerengine/example_test.go
+++ b/engine/badgerengine/example_test.go
@@ -1,6 +1,7 @@
 package badgerengine_test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -12,6 +13,8 @@ import (
 )
 
 func Example() {
+	ctx := context.Background()
+
 	dir, err := ioutil.TempDir("", "badger")
 	if err != nil {
 		log.Fatal(err)
@@ -23,7 +26,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	db, err := genji.New(ng)
+	db, err := genji.New(ctx, ng)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/boltengine/example_test.go
+++ b/engine/boltengine/example_test.go
@@ -1,6 +1,7 @@
 package boltengine_test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -11,13 +12,15 @@ import (
 )
 
 func Example() {
+	ctx := context.Background()
+
 	dir, err := ioutil.TempDir("", "bolt")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
-	db, err := genji.Open(path.Join(dir, "my.db"))
+	db, err := genji.Open(ctx, path.Join(dir, "my.db"))
 	defer db.Close()
 	if err != nil {
 		log.Fatal(err)
@@ -25,6 +28,8 @@ func Example() {
 }
 
 func ExampleNewEngine() {
+	ctx := context.Background()
+
 	dir, err := ioutil.TempDir("", "bolt")
 	if err != nil {
 		log.Fatal(err)
@@ -36,7 +41,7 @@ func ExampleNewEngine() {
 		log.Fatal(err)
 	}
 
-	db, err := genji.New(ng)
+	db, err := genji.New(ctx, ng)
 	defer db.Close()
 	if err != nil {
 		log.Fatal(err)

--- a/engine/boltengine/store.go
+++ b/engine/boltengine/store.go
@@ -86,15 +86,15 @@ type iterator struct {
 	item    boltItem
 }
 
-func (it *iterator) Seek(ctx context.Context, pivot []byte) error {
+func (it *iterator) Seek(ctx context.Context, pivot []byte) {
 	if !it.reverse {
 		it.item.k, it.item.v = it.c.Seek(pivot)
-		return nil
+		return
 	}
 
 	if len(pivot) == 0 {
 		it.item.k, it.item.v = it.c.Last()
-		return nil
+		return
 	}
 
 	it.item.k, it.item.v = it.c.Seek(pivot)
@@ -103,20 +103,21 @@ func (it *iterator) Seek(ctx context.Context, pivot []byte) error {
 			it.item.k, it.item.v = it.c.Prev()
 		}
 	}
-
-	return nil
 }
 
 func (it *iterator) Valid() bool {
 	return it.item.k != nil
 }
 
-func (it *iterator) Next(ctx context.Context) error {
+func (it *iterator) Next(ctx context.Context) {
 	if it.reverse {
 		it.item.k, it.item.v = it.c.Prev()
 	} else {
 		it.item.k, it.item.v = it.c.Next()
 	}
+}
+
+func (it *iterator) Err() error {
 	return nil
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -87,9 +87,12 @@ type IteratorOptions struct {
 type Iterator interface {
 	// Seek moves the iterator to the selected key. If the key doesn't exist, it must move to the
 	// next smallest key greater than k.
-	Seek(ctx context.Context, k []byte) error
+	Seek(ctx context.Context, k []byte)
 	// Next moves the iterator to the next item.
-	Next(ctx context.Context) error
+	Next(ctx context.Context)
+	// Err returns an error that aborted iteration on Seek or Next.
+	// If Err is not nil then Valid must return false.
+	Err() error
 	// Valid returns whether the iterator is positioned on a valid item or not.
 	Valid() bool
 	// Item returns the current item.

--- a/engine/enginetest/benchmark.go
+++ b/engine/enginetest/benchmark.go
@@ -2,6 +2,7 @@ package enginetest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,6 +12,8 @@ import (
 
 // BenchmarkStorePut benchmarks the Put method with 1, 10, 1000 and 10000 successive insertions.
 func BenchmarkStorePut(b *testing.B, builder Builder) {
+	ctx := context.Background()
+
 	v := bytes.Repeat([]byte("v"), 512)
 
 	for size := 1; size <= 10000; size *= 10 {
@@ -21,7 +24,7 @@ func BenchmarkStorePut(b *testing.B, builder Builder) {
 				for j := 0; j < size; j++ {
 					k := []byte(fmt.Sprintf("k%d", j))
 
-					st.Put(k, v)
+					st.Put(ctx, k, v)
 				}
 				cleanup()
 			}
@@ -31,6 +34,8 @@ func BenchmarkStorePut(b *testing.B, builder Builder) {
 
 // BenchmarkStoreScan benchmarks the AscendGreaterOrEqual method with 1, 10, 1000 and 10000 successive insertions.
 func BenchmarkStoreScan(b *testing.B, builder Builder) {
+	ctx := context.Background()
+
 	for size := 1; size <= 10000; size *= 10 {
 		b.Run(fmt.Sprintf("%.05d", size), func(b *testing.B) {
 			st, cleanup := storeBuilder(b, builder)
@@ -40,17 +45,19 @@ func BenchmarkStoreScan(b *testing.B, builder Builder) {
 
 			for i := 0; i < size; i++ {
 				k := []byte(fmt.Sprintf("k%d", i))
-				err := st.Put(k, v)
+				err := st.Put(ctx, k, v)
 				require.NoError(b, err)
 			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				it := st.NewIterator(engine.IteratorConfig{})
-				for it.Seek(nil); it.Valid(); it.Next() {
+				it := st.Iterator(engine.IteratorOptions{})
+				for it.Seek(ctx, nil); it.Valid(); it.Next(ctx) {
 				}
-				err := it.Close()
-				if err != nil {
+				if err := it.Err(); err != nil {
+					require.NoError(b, err)
+				}
+				if err := it.Close(); err != nil {
 					require.NoError(b, err)
 				}
 			}

--- a/engine/enginetest/testing.go
+++ b/engine/enginetest/testing.go
@@ -945,7 +945,7 @@ func TestQueries(t *testing.T, builder Builder) {
 			SELECT * FROM test;
 		`)
 		require.NoError(t, err)
-		n, err := st.Count(ctx)
+		n, err := st.Count()
 		require.NoError(t, err)
 		require.Equal(t, 4, n)
 		err = st.Close()
@@ -957,7 +957,7 @@ func TestQueries(t *testing.T, builder Builder) {
 			defer st.Close()
 
 			var i int
-			err = st.Iterate(ctx, func(d document.Document) error {
+			err = st.Iterate(func(d document.Document) error {
 				var a int
 				err := document.Scan(d, &a)
 				require.NoError(t, err)
@@ -1002,7 +1002,7 @@ func TestQueries(t *testing.T, builder Builder) {
 		require.NoError(t, err)
 		defer st.Close()
 		var buf bytes.Buffer
-		err = document.IteratorToJSONArray(ctx, &buf, st)
+		err = document.IteratorToJSONArray(&buf, st)
 		require.NoError(t, err)
 		require.JSONEq(t, `[{"a": 5},{"a": 5},{"a": 5},{"a": 5}]`, buf.String())
 	})
@@ -1034,7 +1034,7 @@ func TestQueries(t *testing.T, builder Builder) {
 		`)
 		require.NoError(t, err)
 		defer st.Close()
-		n, err := st.Count(ctx)
+		n, err := st.Count()
 		require.NoError(t, err)
 		require.Equal(t, 2, n)
 	})
@@ -1059,7 +1059,7 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 			`)
 			require.NoError(t, err)
 			defer st.Close()
-			n, err := st.Count(ctx)
+			n, err := st.Count()
 			require.NoError(t, err)
 			require.Equal(t, 4, n)
 			return nil
@@ -1105,7 +1105,7 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 			require.NoError(t, err)
 			defer st.Close()
 			var buf bytes.Buffer
-			err = document.IteratorToJSONArray(ctx, &buf, st)
+			err = document.IteratorToJSONArray(&buf, st)
 			require.NoError(t, err)
 			require.JSONEq(t, `[{"a": 5},{"a": 5},{"a": 5},{"a": 5}]`, buf.String())
 			return nil
@@ -1131,7 +1131,7 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 		`)
 			require.NoError(t, err)
 			defer st.Close()
-			n, err := st.Count(ctx)
+			n, err := st.Count()
 			require.NoError(t, err)
 			require.Equal(t, 2, n)
 			return nil

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -193,7 +193,7 @@ type iterator struct {
 	cancel  func()
 }
 
-func (it *iterator) Seek(ctx context.Context, pivot []byte) error {
+func (it *iterator) Seek(ctx context.Context, pivot []byte) {
 	// make sure any opened goroutine
 	// is closed before creating a new one
 	if it.cancel != nil {
@@ -207,7 +207,7 @@ func (it *iterator) Seek(ctx context.Context, pivot []byte) error {
 
 	it.runIterator(pivot)
 
-	return it.Next(ctx)
+	it.Next(ctx)
 }
 
 // runIterator creates a goroutine that reads from the tree.
@@ -262,8 +262,11 @@ func (it *iterator) Valid() bool {
 }
 
 // Read the next item from the goroutine
-func (it *iterator) Next(ctx context.Context) error {
+func (it *iterator) Next(ctx context.Context) {
 	it.item = <-it.ch
+}
+
+func (it *iterator) Err() error {
 	return nil
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -21,47 +21,45 @@ type User struct {
 }
 
 func Example() {
-	ctx := context.Background()
-
 	// Create a database instance, here we'll store everything in memory
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	if err != nil {
 		panic(err)
 	}
 	defer db.Close()
 
 	// Create a table. Genji tables are schemaless by default, you don't need to specify a schema.
-	err = db.Exec(ctx, "CREATE TABLE user")
+	err = db.Exec("CREATE TABLE user")
 	if err != nil {
 		panic(err)
 	}
 
 	// Create an index.
-	err = db.Exec(ctx, "CREATE INDEX idx_user_name ON user (name)")
+	err = db.Exec("CREATE INDEX idx_user_name ON user (name)")
 	if err != nil {
 		panic(err)
 	}
 
 	// Insert some data
-	err = db.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
+	err = db.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
 	if err != nil {
 		panic(err)
 	}
 
 	// Insert some data using document notation
-	err = db.Exec(ctx, `INSERT INTO user VALUES {id: 12, "name": "bar", age: ?, address: {city: "Lyon", zipcode: "69001"}}`, 16)
+	err = db.Exec(`INSERT INTO user VALUES {id: 12, "name": "bar", age: ?, address: {city: "Lyon", zipcode: "69001"}}`, 16)
 	if err != nil {
 		panic(err)
 	}
 
 	// Structs can be used to describe a document
-	err = db.Exec(ctx, "INSERT INTO user VALUES ?, ?", &User{ID: 1, Name: "baz", Age: 100}, &User{ID: 2, Name: "bat"})
+	err = db.Exec("INSERT INTO user VALUES ?, ?", &User{ID: 1, Name: "baz", Age: 100}, &User{ID: 2, Name: "bat"})
 	if err != nil {
 		panic(err)
 	}
 
 	// Query some documents
-	stream, err := db.Query(ctx, "SELECT * FROM user WHERE id > ?", 1)
+	stream, err := db.Query("SELECT * FROM user WHERE id > ?", 1)
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +67,7 @@ func Example() {
 	defer stream.Close()
 
 	// Iterate over the results
-	err = stream.Iterate(ctx, func(d document.Document) error {
+	err = stream.Iterate(context.Background(), func(d document.Document) error {
 		var u User
 
 		err = document.StructScan(d, &u)
@@ -85,14 +83,14 @@ func Example() {
 	}
 
 	// Count results
-	count, err := stream.Count(ctx)
+	count, err := stream.Count(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println("Count:", count)
 
 	// Get first document from the results
-	d, err := stream.First(ctx)
+	d, err := stream.First(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -129,7 +127,7 @@ func Example() {
 			return &fb, nil
 		}).
 		// Iterate on them
-		Iterate(ctx, func(d document.Document) error {
+		Iterate(context.Background(), func(d document.Document) error {
 			return enc.Encode(d)
 		})
 

--- a/example_test.go
+++ b/example_test.go
@@ -67,7 +67,7 @@ func Example() {
 	defer stream.Close()
 
 	// Iterate over the results
-	err = stream.Iterate(context.Background(), func(d document.Document) error {
+	err = stream.Iterate(func(d document.Document) error {
 		var u User
 
 		err = document.StructScan(d, &u)
@@ -83,14 +83,14 @@ func Example() {
 	}
 
 	// Count results
-	count, err := stream.Count(context.Background())
+	count, err := stream.Count()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println("Count:", count)
 
 	// Get first document from the results
-	d, err := stream.First(context.Background())
+	d, err := stream.First()
 	if err != nil {
 		panic(err)
 	}
@@ -127,7 +127,7 @@ func Example() {
 			return &fb, nil
 		}).
 		// Iterate on them
-		Iterate(context.Background(), func(d document.Document) error {
+		Iterate(func(d document.Document) error {
 			return enc.Encode(d)
 		})
 

--- a/example_test.go
+++ b/example_test.go
@@ -21,14 +21,14 @@ type User struct {
 }
 
 func Example() {
+	ctx := context.Background()
+
 	// Create a database instance, here we'll store everything in memory
-	db, err := genji.Open(":memory:")
+	db, err := genji.Open(ctx, ":memory:")
 	if err != nil {
 		panic(err)
 	}
 	defer db.Close()
-
-	ctx := context.Background()
 
 	// Create a table. Genji tables are schemaless by default, you don't need to specify a schema.
 	err = db.Exec(ctx, "CREATE TABLE user")
@@ -69,7 +69,7 @@ func Example() {
 	defer stream.Close()
 
 	// Iterate over the results
-	err = stream.Iterate(func(d document.Document) error {
+	err = stream.Iterate(ctx, func(d document.Document) error {
 		var u User
 
 		err = document.StructScan(d, &u)
@@ -85,14 +85,14 @@ func Example() {
 	}
 
 	// Count results
-	count, err := stream.Count()
+	count, err := stream.Count(ctx)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println("Count:", count)
 
 	// Get first document from the results
-	d, err := stream.First()
+	d, err := stream.First(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -129,7 +129,7 @@ func Example() {
 			return &fb, nil
 		}).
 		// Iterate on them
-		Iterate(func(d document.Document) error {
+		Iterate(ctx, func(d document.Document) error {
 			return enc.Encode(d)
 		})
 

--- a/index/index.go
+++ b/index/index.go
@@ -286,10 +286,7 @@ func (idx *Index) iterate(ctx context.Context, st engine.Store, pivot document.V
 	it := st.Iterator(engine.IteratorOptions{Reverse: reverse})
 	defer it.Close()
 
-	if err := it.Seek(ctx, seek); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, seek); it.Valid(); it.Next(ctx) {
 		itm := it.Item()
 
 		if idx.Type == 0 && pivot.Type != 0 && itm.Key()[0] != byte(pivot.Type) {
@@ -301,9 +298,9 @@ func (idx *Index) iterate(ctx context.Context, st engine.Store, pivot document.V
 			return err
 		}
 
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/new.go
+++ b/new.go
@@ -3,14 +3,16 @@
 package genji
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document/encoding/msgpack"
 	"github.com/genjidb/genji/engine"
 )
 
 // New initializes the DB using the given engine.
-func New(ng engine.Engine) (*DB, error) {
-	db, err := database.New(ng, database.Options{Codec: msgpack.NewCodec()})
+func New(ctx context.Context, ng engine.Engine) (*DB, error) {
+	db, err := database.New(ctx, ng, database.Options{Codec: msgpack.NewCodec()})
 	if err != nil {
 		return nil, err
 	}

--- a/new.go
+++ b/new.go
@@ -18,6 +18,7 @@ func New(ctx context.Context, ng engine.Engine) (*DB, error) {
 	}
 
 	return &DB{
-		DB: db,
+		DB:      db,
+		Context: ctx,
 	}, nil
 }

--- a/new_wasm.go
+++ b/new_wasm.go
@@ -3,14 +3,16 @@
 package genji
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document/encoding/custom"
 	"github.com/genjidb/genji/engine"
 )
 
 // New initializes the DB using the given engine.
-func New(ng engine.Engine) (*DB, error) {
-	db, err := database.New(ng, database.Options{Codec: custom.NewCodec()})
+func New(ctx context.Context, ng engine.Engine) (*DB, error) {
+	db, err := database.New(ctx, ng, database.Options{Codec: custom.NewCodec()})
 	if err != nil {
 		return nil, err
 	}

--- a/new_wasm.go
+++ b/new_wasm.go
@@ -18,6 +18,7 @@ func New(ctx context.Context, ng engine.Engine) (*DB, error) {
 	}
 
 	return &DB{
-		DB: db,
+		DB:      db,
+		Context: ctx,
 	}, nil
 }

--- a/open.go
+++ b/open.go
@@ -3,6 +3,8 @@
 package genji
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/engine"
 	"github.com/genjidb/genji/engine/boltengine"
 	"github.com/genjidb/genji/engine/memoryengine"
@@ -11,7 +13,7 @@ import (
 // Open creates a Genji database at the given path.
 // If path is equal to ":memory:" it will open an in-memory database,
 // otherwise it will create an on-disk database using the BoltDB engine.
-func Open(path string) (*DB, error) {
+func Open(ctx context.Context, path string) (*DB, error) {
 	var ng engine.Engine
 	var err error
 
@@ -25,5 +27,5 @@ func Open(path string) (*DB, error) {
 		return nil, err
 	}
 
-	return New(ng)
+	return New(ctx, ng)
 }

--- a/sql/driver/driver.go
+++ b/sql/driver/driver.go
@@ -338,7 +338,7 @@ func (rs *documentStream) iterate(ctx context.Context) {
 	case <-rs.c:
 	}
 
-	err := rs.res.Iterate(ctx, func(d document.Document) error {
+	err := rs.res.Iterate(func(d document.Document) error {
 		select {
 		case <-ctx.Done():
 			return errStop

--- a/sql/driver/driver.go
+++ b/sql/driver/driver.go
@@ -126,10 +126,12 @@ func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 		return nil, errors.New("isolation levels are not supported")
 	}
 
+	db := c.db.WithContext(ctx)
+
 	// if the ReadOnly flag is explicitly specified, create a read-only transaction,
 	// otherwise create a read/write transaction.
 	var err error
-	c.tx, err = c.db.Begin(ctx, !opts.ReadOnly)
+	c.tx, err = db.Begin(!opts.ReadOnly)
 
 	return c, err
 }

--- a/sql/planner/binder.go
+++ b/sql/planner/binder.go
@@ -1,36 +1,38 @@
 package planner
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/sql/query/expr"
 )
 
 // Bind updates every node that refers to a database ressource.
-func Bind(t *Tree, tx *database.Transaction, params []expr.Param) error {
+func Bind(ctx context.Context, t *Tree, tx *database.Transaction, params []expr.Param) error {
 	if t.Root != nil {
-		return bindNode(t.Root, tx, params)
+		return bindNode(ctx, t.Root, tx, params)
 	}
 
 	return nil
 }
 
-func bindNode(n Node, tx *database.Transaction, params []expr.Param) error {
+func bindNode(ctx context.Context, n Node, tx *database.Transaction, params []expr.Param) error {
 	var err error
 
-	err = n.Bind(tx, params)
+	err = n.Bind(ctx, tx, params)
 	if err != nil {
 		return err
 	}
 
 	if n.Left() != nil {
-		err = bindNode(n.Left(), tx, params)
+		err = bindNode(ctx, n.Left(), tx, params)
 		if err != nil {
 			return err
 		}
 	}
 
 	if n.Right() != nil {
-		err = bindNode(n.Right(), tx, params)
+		err = bindNode(ctx, n.Right(), tx, params)
 		if err != nil {
 			return err
 		}

--- a/sql/planner/deletion.go
+++ b/sql/planner/deletion.go
@@ -54,7 +54,7 @@ func (n *deletionNode) toStream(ctx context.Context, st document.Stream) (docume
 	for {
 		var i int
 
-		err := st.Iterate(ctx, func(d document.Document) error {
+		err := st.Iterate(func(d document.Document) error {
 			k, ok := d.(document.Keyer)
 			if !ok {
 				return errors.New("attempt to delete document without key")

--- a/sql/planner/explain.go
+++ b/sql/planner/explain.go
@@ -24,12 +24,12 @@ type ExplainStmt struct {
 func (s *ExplainStmt) Run(ctx context.Context, tx *database.Transaction, params []expr.Param) (query.Result, error) {
 	switch t := s.Statement.(type) {
 	case *Tree:
-		err := Bind(t, tx, params)
+		err := Bind(ctx, t, tx, params)
 		if err != nil {
 			return query.Result{}, err
 		}
 
-		t, err = Optimize(t)
+		t, err = Optimize(ctx, t)
 		if err != nil {
 			return query.Result{}, err
 		}

--- a/sql/planner/explain_test.go
+++ b/sql/planner/explain_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestExplainStmt(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		query    string
 		fails    bool
@@ -36,11 +38,9 @@ func TestExplainStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
-
-			ctx := context.Background()
 
 			err = db.Exec(ctx, "CREATE TABLE test (k INTEGER PRIMARY KEY)")
 			require.NoError(t, err)

--- a/sql/planner/explain_test.go
+++ b/sql/planner/explain_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestExplainStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		query    string
 		fails    bool
@@ -38,19 +36,19 @@ func TestExplainStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test (k INTEGER PRIMARY KEY)")
+			err = db.Exec("CREATE TABLE test (k INTEGER PRIMARY KEY)")
 			require.NoError(t, err)
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 						CREATE INDEX idx_a ON test (a);
 						CREATE UNIQUE INDEX idx_b ON test (b);
 					`)
 			require.NoError(t, err)
 
-			d, err := db.QueryDocument(ctx, test.query)
+			d, err := db.QueryDocument(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return

--- a/sql/planner/optimizer_test.go
+++ b/sql/planner/optimizer_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestSplitANDConditionRule(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name           string
 		root, expected planner.Node
@@ -87,6 +85,7 @@ func TestSplitANDConditionRule(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			res, err := planner.SplitANDConditionRule(ctx, planner.NewTree(test.root))
 			require.NoError(t, err)
 			require.Equal(t, res.String(), planner.NewTree(test.expected).String())
@@ -95,8 +94,6 @@ func TestSplitANDConditionRule(t *testing.T) {
 }
 
 func TestPrecalculateExprRule(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name        string
 		e, expected expr.Expr
@@ -168,6 +165,7 @@ func TestPrecalculateExprRule(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			res, err := planner.PrecalculateExprRule(ctx, planner.NewTree(planner.NewSelectionNode(planner.NewTableInputNode("foo"), test.e)))
 			require.NoError(t, err)
 			require.Equal(t, planner.NewTree(planner.NewSelectionNode(planner.NewTableInputNode("foo"), test.expected)).String(), res.String())
@@ -176,8 +174,6 @@ func TestPrecalculateExprRule(t *testing.T) {
 }
 
 func TestRemoveUnnecessarySelectionNodesRule(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name           string
 		root, expected planner.Node
@@ -201,6 +197,7 @@ func TestRemoveUnnecessarySelectionNodesRule(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			res, err := planner.RemoveUnnecessarySelectionNodesRule(ctx, planner.NewTree(test.root))
 			require.NoError(t, err)
 			if test.expected != nil {
@@ -213,8 +210,6 @@ func TestRemoveUnnecessarySelectionNodesRule(t *testing.T) {
 }
 
 func TestUseIndexBasedOnSelectionNodeRule(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name           string
 		root, expected planner.Node
@@ -347,15 +342,16 @@ func TestUseIndexBasedOnSelectionNodeRule(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			tx, err := db.Begin(ctx, true)
+			tx, err := db.Begin(true)
 			require.NoError(t, err)
 			defer tx.Rollback()
 
-			err = tx.Exec(ctx, `
+			err = tx.Exec(`
 				CREATE TABLE foo;
 				CREATE INDEX idx_foo_a ON foo(a);
 				CREATE INDEX idx_foo_b ON foo(b);

--- a/sql/planner/projection.go
+++ b/sql/planner/projection.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -38,18 +39,18 @@ func NewProjectionNode(n Node, expressions []ProjectedField, tableName string) N
 }
 
 // Bind database resources to this node.
-func (n *ProjectionNode) Bind(tx *database.Transaction, params []expr.Param) (err error) {
+func (n *ProjectionNode) Bind(ctx context.Context, tx *database.Transaction, params []expr.Param) (err error) {
 	n.tx = tx
 	if n.tableName == "" {
 		return
 	}
 
-	table, err := tx.GetTable(n.tableName)
+	table, err := tx.GetTable(ctx, n.tableName)
 	if err != nil {
 		return err
 	}
 
-	n.info, err = table.Info()
+	n.info, err = table.Info(ctx)
 	return
 }
 
@@ -59,7 +60,7 @@ type AggregatorBuilder interface {
 	SetAlias(string)
 }
 
-func (n *ProjectionNode) toStream(st document.Stream) (document.Stream, error) {
+func (n *ProjectionNode) toStream(ctx context.Context, st document.Stream) (document.Stream, error) {
 	var aggBuilders []document.AggregatorBuilder
 
 	for _, e := range n.Expressions {

--- a/sql/planner/replacement.go
+++ b/sql/planner/replacement.go
@@ -64,7 +64,7 @@ func (n *replacementNode) toStream(ctx context.Context, st document.Stream) (doc
 	for {
 		var i int
 
-		err = st.Iterate(ctx, func(d document.Document) error {
+		err = st.Iterate(func(d document.Document) error {
 			rk, ok := d.(document.Keyer)
 			if !ok || rk == nil {
 				return errors.New("attempt to replace document without key")

--- a/sql/planner/replacement.go
+++ b/sql/planner/replacement.go
@@ -122,10 +122,7 @@ func (u *resumableIterator) Iterate(ctx context.Context, fn func(d document.Docu
 	defer it.Close()
 
 	var buf []byte
-	if err := it.Seek(ctx, u.curKey); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, u.curKey); it.Valid(); it.Next(ctx) {
 		item := it.Item()
 
 		d.key = item.Key()
@@ -139,10 +136,9 @@ func (u *resumableIterator) Iterate(ctx context.Context, fn func(d document.Docu
 		if err != nil {
 			return err
 		}
-
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/sql/planner/sort.go
+++ b/sql/planner/sort.go
@@ -66,8 +66,8 @@ type sortIterator struct {
 	direction scanner.Token
 }
 
-func (it *sortIterator) Iterate(ctx context.Context, fn func(d document.Document) error) error {
-	h, err := it.sortStream(ctx, it.st)
+func (it *sortIterator) Iterate(fn func(d document.Document) error) error {
+	h, err := it.sortStream(it.st)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (it *sortIterator) Iterate(ctx context.Context, fn func(d document.Document
 // the chosen sorting order (ASC or DESC).
 // This function is not memory efficient as it's loading the entire stream in memory before
 // returning the k-smallest or k-largest elements.
-func (it *sortIterator) sortStream(ctx context.Context, st document.Stream) (heap.Interface, error) {
+func (it *sortIterator) sortStream(st document.Stream) (heap.Interface, error) {
 	path := document.ValuePath(it.sortField)
 
 	var h heap.Interface
@@ -105,7 +105,7 @@ func (it *sortIterator) sortStream(ctx context.Context, st document.Stream) (hea
 
 	heap.Init(h)
 
-	return h, st.Iterate(ctx, func(d document.Document) error {
+	return h, st.Iterate(func(d document.Document) error {
 		// It is possible to sort by any projected field
 		// or field of the original document.
 		v, err := path.GetValue(d)

--- a/sql/planner/tree.go
+++ b/sql/planner/tree.go
@@ -133,7 +133,7 @@ func nodeToStream(ctx context.Context, n Node) (st document.Stream, err error) {
 
 	switch t := n.(type) {
 	case inputNode:
-		st, err = t.buildStream()
+		st, err = t.buildStream(ctx)
 	case operationNode:
 		st, err = t.toStream(ctx, st)
 	default:
@@ -156,7 +156,7 @@ type Node interface {
 type inputNode interface {
 	Node
 
-	buildStream() (document.Stream, error)
+	buildStream(ctx context.Context) (document.Stream, error)
 }
 
 type operationNode interface {

--- a/sql/query/alter.go
+++ b/sql/query/alter.go
@@ -36,6 +36,6 @@ func (stmt AlterStmt) Run(ctx context.Context, tx *database.Transaction, _ []exp
 		return res, database.ErrTableAlreadyExists
 	}
 
-	err := tx.RenameTable(stmt.TableName, stmt.NewTableName)
+	err := tx.RenameTable(ctx, stmt.TableName, stmt.NewTableName)
 	return res, err
 }

--- a/sql/query/alter_test.go
+++ b/sql/query/alter_test.go
@@ -13,7 +13,7 @@ import (
 func TestAlterTable(t *testing.T) {
 	ctx := context.Background()
 
-	db, err := genji.Open(":memory:")
+	db, err := genji.Open(ctx, ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/sql/query/alter_test.go
+++ b/sql/query/alter_test.go
@@ -11,36 +11,34 @@ import (
 )
 
 func TestAlterTable(t *testing.T) {
-	ctx := context.Background()
-
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
 
-	err = db.Exec(ctx, "CREATE TABLE foo")
+	err = db.Exec("CREATE TABLE foo")
 	require.NoError(t, err)
 
 	// Insert some data into foo
-	err = db.Exec(ctx, `INSERT INTO foo VALUES {name: "John Doe", age: 99}`)
+	err = db.Exec(`INSERT INTO foo VALUES {name: "John Doe", age: 99}`)
 	require.NoError(t, err)
 
 	// Renaming the table to the same name should fail.
-	err = db.Exec(ctx, "ALTER TABLE foo RENAME TO foo")
+	err = db.Exec("ALTER TABLE foo RENAME TO foo")
 	require.EqualError(t, err, database.ErrTableAlreadyExists.Error())
 
-	err = db.Exec(ctx, "ALTER TABLE foo RENAME TO bar")
+	err = db.Exec("ALTER TABLE foo RENAME TO bar")
 	require.NoError(t, err)
 
 	// Selecting from the old name should fail.
-	err = db.Exec(ctx, "SELECT * FROM foo")
+	err = db.Exec("SELECT * FROM foo")
 	require.EqualError(t, err, database.ErrTableNotFound.Error())
 
-	d, err := db.QueryDocument(ctx, "SELECT * FROM bar")
+	d, err := db.QueryDocument("SELECT * FROM bar")
 	data, err := document.MarshalJSON(d)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"name": "John Doe", "age": 99}`, string(data))
 
 	// Renaming a read-only table should fail
-	err = db.Exec(ctx, "ALTER TABLE __genji_tables RENAME TO bar")
+	err = db.Exec("ALTER TABLE __genji_tables RENAME TO bar")
 	require.Error(t, err)
 }

--- a/sql/query/create.go
+++ b/sql/query/create.go
@@ -30,7 +30,7 @@ func (stmt CreateTableStmt) Run(ctx context.Context, tx *database.Transaction, a
 		return res, errors.New("missing table name")
 	}
 
-	err := tx.CreateTable(stmt.TableName, &stmt.Info)
+	err := tx.CreateTable(ctx, stmt.TableName, &stmt.Info)
 	if stmt.IfNotExists && err == database.ErrTableAlreadyExists {
 		err = nil
 	}
@@ -70,7 +70,7 @@ func (stmt CreateIndexStmt) Run(ctx context.Context, tx *database.Transaction, a
 		return res, errors.New("missing path")
 	}
 
-	err := tx.CreateIndex(database.IndexConfig{
+	err := tx.CreateIndex(ctx, database.IndexConfig{
 		Unique:    stmt.Unique,
 		IndexName: stmt.IndexName,
 		TableName: stmt.TableName,

--- a/sql/query/create_test.go
+++ b/sql/query/create_test.go
@@ -18,8 +18,6 @@ func parsePath(t testing.TB, str string) document.ValuePath {
 }
 
 func TestCreateTable(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name  string
 		query string
@@ -36,18 +34,19 @@ func TestCreateTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, test.query)
+			err = db.Exec(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			err = db.View(ctx, func(tx *genji.Tx) error {
+			err = db.View(func(tx *genji.Tx) error {
 				_, err := tx.GetTable(ctx, "test")
 				return err
 			})
@@ -56,15 +55,16 @@ func TestCreateTable(t *testing.T) {
 	}
 
 	t.Run("constraints", func(t *testing.T) {
+		ctx := context.Background()
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
 		t.Run("with fixed size data types", func(t *testing.T) {
-			err = db.Exec(ctx, `CREATE TABLE test(d double, b bool)`)
+			err = db.Exec(`CREATE TABLE test(d double, b bool)`)
 			require.NoError(t, err)
 
-			err = db.View(ctx, func(tx *genji.Tx) error {
+			err = db.View(func(tx *genji.Tx) error {
 				tb, err := tx.GetTable(ctx, "test")
 				if err != nil {
 					return err
@@ -86,14 +86,14 @@ func TestCreateTable(t *testing.T) {
 		})
 
 		t.Run("with variable size data types", func(t *testing.T) {
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 				CREATE TABLE test1(
 					foo.bar[1].hello bytes PRIMARY KEY, foo.a[1][2] TEXT NOT NULL, bar[4][0].bat integer, b blob, t text, a array, d document
 				)
 			`)
 			require.NoError(t, err)
 
-			err = db.View(ctx, func(tx *genji.Tx) error {
+			err = db.View(func(tx *genji.Tx) error {
 				tb, err := tx.GetTable(ctx, "test1")
 				if err != nil {
 					return err
@@ -121,8 +121,6 @@ func TestCreateTable(t *testing.T) {
 }
 
 func TestCreateIndex(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name  string
 		query string
@@ -137,14 +135,15 @@ func TestCreateIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query)
+			err = db.Exec(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return

--- a/sql/query/create_test.go
+++ b/sql/query/create_test.go
@@ -36,7 +36,7 @@ func TestCreateTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -47,8 +47,8 @@ func TestCreateTable(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			err = db.View(func(tx *genji.Tx) error {
-				_, err := tx.GetTable("test")
+			err = db.View(ctx, func(tx *genji.Tx) error {
+				_, err := tx.GetTable(ctx, "test")
 				return err
 			})
 			require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestCreateTable(t *testing.T) {
 	}
 
 	t.Run("constraints", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -64,13 +64,13 @@ func TestCreateTable(t *testing.T) {
 			err = db.Exec(ctx, `CREATE TABLE test(d double, b bool)`)
 			require.NoError(t, err)
 
-			err = db.View(func(tx *genji.Tx) error {
-				tb, err := tx.GetTable("test")
+			err = db.View(ctx, func(tx *genji.Tx) error {
+				tb, err := tx.GetTable(ctx, "test")
 				if err != nil {
 					return err
 				}
 
-				info, err := tb.Info()
+				info, err := tb.Info(ctx)
 				if err != nil {
 					return err
 				}
@@ -93,12 +93,12 @@ func TestCreateTable(t *testing.T) {
 			`)
 			require.NoError(t, err)
 
-			err = db.View(func(tx *genji.Tx) error {
-				tb, err := tx.GetTable("test1")
+			err = db.View(ctx, func(tx *genji.Tx) error {
+				tb, err := tx.GetTable(ctx, "test1")
 				if err != nil {
 					return err
 				}
-				info, err := tb.Info()
+				info, err := tb.Info(ctx)
 				if err != nil {
 					return err
 				}
@@ -121,6 +121,8 @@ func TestCreateTable(t *testing.T) {
 }
 
 func TestCreateIndex(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		name  string
 		query string
@@ -135,11 +137,9 @@ func TestCreateIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
-
-			ctx := context.Background()
 
 			err = db.Exec(ctx, "CREATE TABLE test")
 			require.NoError(t, err)

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -28,7 +28,7 @@ func TestDeleteStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -53,7 +53,7 @@ func TestDeleteStmt(t *testing.T) {
 			defer st.Close()
 
 			var buf bytes.Buffer
-			err = document.IteratorToJSON(&buf, st)
+			err = document.IteratorToJSON(ctx, &buf, st)
 			require.NoError(t, err)
 			if len(test.expected) == 0 {
 				require.Equal(t, 0, buf.Len())

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestDeleteStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -28,27 +26,28 @@ func TestDeleteStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b) VALUES ('foo2', 'bar1')")
+			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar1')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (d, b, e) VALUES ('foo3', 'bar2', 'bar3')")
+			err = db.Exec("INSERT INTO test (d, b, e) VALUES ('foo3', 'bar2', 'bar3')")
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query, test.params...)
+			err = db.Exec(test.query, test.params...)
 			if test.fails {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			st, err := db.Query(ctx, "SELECT * FROM test")
+			st, err := db.Query("SELECT * FROM test")
 			require.NoError(t, err)
 			defer st.Close()
 

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -26,8 +26,7 @@ func TestDeleteStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -52,7 +51,7 @@ func TestDeleteStmt(t *testing.T) {
 			defer st.Close()
 
 			var buf bytes.Buffer
-			err = document.IteratorToJSON(ctx, &buf, st)
+			err = document.IteratorToJSON(&buf, st)
 			require.NoError(t, err)
 			if len(test.expected) == 0 {
 				require.Equal(t, 0, buf.Len())

--- a/sql/query/drop.go
+++ b/sql/query/drop.go
@@ -28,7 +28,7 @@ func (stmt DropTableStmt) Run(ctx context.Context, tx *database.Transaction, arg
 		return res, errors.New("missing table name")
 	}
 
-	err := tx.DropTable(stmt.TableName)
+	err := tx.DropTable(ctx, stmt.TableName)
 	if err == database.ErrTableNotFound && stmt.IfExists {
 		err = nil
 	}
@@ -56,7 +56,7 @@ func (stmt DropIndexStmt) Run(ctx context.Context, tx *database.Transaction, arg
 		return res, errors.New("missing index name")
 	}
 
-	err := tx.DropIndex(stmt.IndexName)
+	err := tx.DropIndex(ctx, stmt.IndexName)
 	if err == database.ErrIndexNotFound && stmt.IfExists {
 		err = nil
 	}

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -12,27 +12,26 @@ import (
 
 func TestDropTable(t *testing.T) {
 	ctx := context.Background()
-
 	db, err := genji.Open(ctx, ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
 
-	err = db.Exec(ctx, "CREATE TABLE test1; CREATE TABLE test2; CREATE TABLE test3")
+	err = db.Exec("CREATE TABLE test1; CREATE TABLE test2; CREATE TABLE test3")
 	require.NoError(t, err)
 
-	err = db.Exec(ctx, "DROP TABLE test1")
+	err = db.Exec("DROP TABLE test1")
 	require.NoError(t, err)
 
-	err = db.Exec(ctx, "DROP TABLE IF EXISTS test1")
+	err = db.Exec("DROP TABLE IF EXISTS test1")
 	require.NoError(t, err)
 
 	// Dropping a table that doesn't exist without "IF EXISTS"
 	// should return an error.
-	err = db.Exec(ctx, "DROP TABLE test1")
+	err = db.Exec("DROP TABLE test1")
 	require.Error(t, err)
 
 	// Assert that only the table `test1` has been dropped.
-	res, err := db.Query(ctx, "SELECT table_name FROM __genji_tables")
+	res, err := db.Query("SELECT table_name FROM __genji_tables")
 	require.NoError(t, err)
 	var tables []string
 	err = res.Iterate(ctx, func(d document.Document) error {
@@ -49,29 +48,28 @@ func TestDropTable(t *testing.T) {
 	require.Len(t, tables, 2)
 
 	// Dropping a read-only table should fail.
-	err = db.Exec(ctx, "DROP TABLE __genji_tables")
+	err = db.Exec("DROP TABLE __genji_tables")
 	require.Error(t, err)
 }
 
 func TestDropIndex(t *testing.T) {
 	ctx := context.Background()
-
 	db, err := genji.Open(ctx, ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
 
-	err = db.Exec(ctx, `
+	err = db.Exec(`
 		CREATE TABLE test1(foo text); CREATE INDEX idx_test1_foo ON test1(foo);
 		CREATE TABLE test2(bar text); CREATE INDEX idx_test2_bar ON test2(bar);
 	`)
 	require.NoError(t, err)
 
-	err = db.Exec(ctx, "DROP INDEX idx_test2_bar")
+	err = db.Exec("DROP INDEX idx_test2_bar")
 	require.NoError(t, err)
 
 	// Assert that the good index has been dropped.
 	var indexes []*database.IndexConfig
-	err = db.View(ctx, func(tx *genji.Tx) error {
+	err = db.View(func(tx *genji.Tx) error {
 		var err error
 		indexes, err = tx.ListIndexes(ctx)
 		return err

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestDropTable(t *testing.T) {
-	db, err := genji.Open(":memory:")
+	ctx := context.Background()
+
+	db, err := genji.Open(ctx, ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
-
-	ctx := context.Background()
 
 	err = db.Exec(ctx, "CREATE TABLE test1; CREATE TABLE test2; CREATE TABLE test3")
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestDropTable(t *testing.T) {
 	res, err := db.Query(ctx, "SELECT table_name FROM __genji_tables")
 	require.NoError(t, err)
 	var tables []string
-	err = res.Iterate(func(d document.Document) error {
+	err = res.Iterate(ctx, func(d document.Document) error {
 		v, err := d.GetByField("table_name")
 		if err != nil {
 			return err
@@ -54,11 +54,11 @@ func TestDropTable(t *testing.T) {
 }
 
 func TestDropIndex(t *testing.T) {
-	db, err := genji.Open(":memory:")
+	ctx := context.Background()
+
+	db, err := genji.Open(ctx, ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
-
-	ctx := context.Background()
 
 	err = db.Exec(ctx, `
 		CREATE TABLE test1(foo text); CREATE INDEX idx_test1_foo ON test1(foo);
@@ -71,9 +71,9 @@ func TestDropIndex(t *testing.T) {
 
 	// Assert that the good index has been dropped.
 	var indexes []*database.IndexConfig
-	err = db.View(func(tx *genji.Tx) error {
+	err = db.View(ctx, func(tx *genji.Tx) error {
 		var err error
-		indexes, err = tx.ListIndexes()
+		indexes, err = tx.ListIndexes(ctx)
 		return err
 	})
 	require.Len(t, indexes, 1)

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestDropTable(t *testing.T) {
-	ctx := context.Background()
-	db, err := genji.Open(ctx, ":memory:")
+	db, err := genji.Open(context.Background(), ":memory:")
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -34,7 +33,7 @@ func TestDropTable(t *testing.T) {
 	res, err := db.Query("SELECT table_name FROM __genji_tables")
 	require.NoError(t, err)
 	var tables []string
-	err = res.Iterate(ctx, func(d document.Document) error {
+	err = res.Iterate(func(d document.Document) error {
 		v, err := d.GetByField("table_name")
 		if err != nil {
 			return err

--- a/sql/query/expr/comparison.go
+++ b/sql/query/expr/comparison.go
@@ -139,10 +139,7 @@ func (op gtOp) IteratePK(ctx context.Context, tb *database.Table, v document.Val
 	defer it.Close()
 
 	var buf []byte
-	if err := it.Seek(ctx, data); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, data); it.Valid(); it.Next(ctx) {
 		buf, err = it.Item().ValueCopy(buf)
 		if err != nil {
 			return err
@@ -155,10 +152,9 @@ func (op gtOp) IteratePK(ctx context.Context, tb *database.Table, v document.Val
 		if err != nil {
 			return err
 		}
-
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -209,10 +205,7 @@ func (op gteOp) IteratePK(ctx context.Context, tb *database.Table, v document.Va
 	defer it.Close()
 
 	var buf []byte
-	if err := it.Seek(ctx, data); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, data); it.Valid(); it.Next(ctx) {
 		buf, err = it.Item().ValueCopy(buf)
 		if err != nil {
 			return err
@@ -222,10 +215,9 @@ func (op gteOp) IteratePK(ctx context.Context, tb *database.Table, v document.Va
 		if err != nil {
 			return err
 		}
-
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -293,10 +285,7 @@ func (op ltOp) IteratePK(ctx context.Context, tb *database.Table, v document.Val
 	defer it.Close()
 
 	var buf []byte
-	if err := it.Seek(ctx, nil); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, nil); it.Valid(); it.Next(ctx) {
 		buf, err = it.Item().ValueCopy(buf)
 		if err != nil {
 			return err
@@ -309,10 +298,9 @@ func (op ltOp) IteratePK(ctx context.Context, tb *database.Table, v document.Val
 		if err != nil {
 			return err
 		}
-
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -381,10 +369,7 @@ func (op lteOp) IteratePK(ctx context.Context, tb *database.Table, v document.Va
 	defer it.Close()
 
 	var buf []byte
-	if err := it.Seek(ctx, nil); err != nil {
-		return err
-	}
-	for it.Valid() {
+	for it.Seek(ctx, nil); it.Valid(); it.Next(ctx) {
 		buf, err = it.Item().ValueCopy(buf)
 		if err != nil {
 			return err
@@ -397,10 +382,9 @@ func (op lteOp) IteratePK(ctx context.Context, tb *database.Table, v document.Va
 		if err != nil {
 			return err
 		}
-
-		if err := it.Next(ctx); err != nil {
-			return err
-		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/sql/query/insert.go
+++ b/sql/query/insert.go
@@ -35,7 +35,7 @@ func (stmt InsertStmt) Run(ctx context.Context, tx *database.Transaction, args [
 		return res, errors.New("values are empty")
 	}
 
-	t, err := tx.GetTable(stmt.TableName)
+	t, err := tx.GetTable(ctx, stmt.TableName)
 	if err != nil {
 		return res, err
 	}
@@ -46,13 +46,13 @@ func (stmt InsertStmt) Run(ctx context.Context, tx *database.Transaction, args [
 	}
 
 	if len(stmt.FieldNames) > 0 {
-		return stmt.insertExprList(t, stack)
+		return stmt.insertExprList(ctx, t, stack)
 	}
 
-	return stmt.insertDocuments(t, stack)
+	return stmt.insertDocuments(ctx, t, stack)
 }
 
-func (stmt InsertStmt) insertDocuments(t *database.Table, stack expr.EvalStack) (Result, error) {
+func (stmt InsertStmt) insertDocuments(ctx context.Context, t *database.Table, stack expr.EvalStack) (Result, error) {
 	var res Result
 
 	for _, e := range stmt.Values {
@@ -65,7 +65,7 @@ func (stmt InsertStmt) insertDocuments(t *database.Table, stack expr.EvalStack) 
 			return res, fmt.Errorf("expected document, got %s", v.Type)
 		}
 
-		res.LastInsertKey, err = t.Insert(v.V.(document.Document))
+		res.LastInsertKey, err = t.Insert(ctx, v.V.(document.Document))
 		if err != nil {
 			return res, err
 		}
@@ -76,7 +76,7 @@ func (stmt InsertStmt) insertDocuments(t *database.Table, stack expr.EvalStack) 
 	return res, nil
 }
 
-func (stmt InsertStmt) insertExprList(t *database.Table, stack expr.EvalStack) (Result, error) {
+func (stmt InsertStmt) insertExprList(ctx context.Context, t *database.Table, stack expr.EvalStack) (Result, error) {
 	var res Result
 
 	// iterate over all of the documents (r1, r2, r3, ...)
@@ -105,7 +105,7 @@ func (stmt InsertStmt) insertExprList(t *database.Table, stack expr.EvalStack) (
 			return nil
 		})
 
-		res.LastInsertKey, err = t.Insert(&fb)
+		res.LastInsertKey, err = t.Insert(ctx, &fb)
 		if err != nil {
 			return res, err
 		}

--- a/sql/query/insert_test.go
+++ b/sql/query/insert_test.go
@@ -46,7 +46,7 @@ func TestInsertStmt(t *testing.T) {
 	for _, test := range tests {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
-				db, err := genji.Open(":memory:")
+				db, err := genji.Open(ctx, ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
 
@@ -74,7 +74,7 @@ func TestInsertStmt(t *testing.T) {
 				defer st.Close()
 
 				var buf bytes.Buffer
-				err = document.IteratorToJSON(&buf, st)
+				err = document.IteratorToJSON(ctx, &buf, st)
 				require.NoError(t, err)
 				require.JSONEq(t, test.expected, buf.String())
 			}
@@ -85,7 +85,7 @@ func TestInsertStmt(t *testing.T) {
 	}
 
 	t.Run("with primary key", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -102,7 +102,7 @@ func TestInsertStmt(t *testing.T) {
 	})
 
 	t.Run("with shadowing", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -114,7 +114,7 @@ func TestInsertStmt(t *testing.T) {
 	})
 
 	t.Run("with struct param", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -133,14 +133,14 @@ func TestInsertStmt(t *testing.T) {
 
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		err = document.IteratorToJSON(&buf, res)
+		err = document.IteratorToJSON(ctx, &buf, res)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"a": "a", "b-b": "b"}`, buf.String())
 	})
 
 	t.Run("with types constraints", func(t *testing.T) {
 		// This test ensures that we can insert data into every supported types.
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -165,7 +165,7 @@ func TestInsertStmt(t *testing.T) {
 		require.NoError(t, err)
 
 		var buf bytes.Buffer
-		err = document.IteratorToJSON(&buf, res)
+		err = document.IteratorToJSON(ctx, &buf, res)
 		require.NoError(t, err)
 		require.JSONEq(t, `{
 			"i": 10000000000,
@@ -215,7 +215,7 @@ func TestInsertStmt(t *testing.T) {
 			{"text / not null with type constraint", "TEXT NOT NULL", `{}`},
 		}
 
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 

--- a/sql/query/insert_test.go
+++ b/sql/query/insert_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestInsertStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -46,11 +44,11 @@ func TestInsertStmt(t *testing.T) {
 	for _, test := range tests {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
+				ctx := context.Background()
+
 				db, err := genji.Open(ctx, ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
-
-				ctx := context.Background()
 
 				err = db.Exec(ctx, "CREATE TABLE test")
 				require.NoError(t, err)
@@ -85,6 +83,8 @@ func TestInsertStmt(t *testing.T) {
 	}
 
 	t.Run("with primary key", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
@@ -102,6 +102,8 @@ func TestInsertStmt(t *testing.T) {
 	})
 
 	t.Run("with shadowing", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
@@ -114,6 +116,8 @@ func TestInsertStmt(t *testing.T) {
 	})
 
 	t.Run("with struct param", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
@@ -139,6 +143,8 @@ func TestInsertStmt(t *testing.T) {
 	})
 
 	t.Run("with types constraints", func(t *testing.T) {
+		ctx := context.Background()
+
 		// This test ensures that we can insert data into every supported types.
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
@@ -215,17 +221,19 @@ func TestInsertStmt(t *testing.T) {
 			{"text / not null with type constraint", "TEXT NOT NULL", `{}`},
 		}
 
-		db, err := genji.Open(ctx, ":memory:")
-		require.NoError(t, err)
-		defer db.Close()
-
-		for i, test := range tests {
+		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				q := fmt.Sprintf("CREATE TABLE test%d (a %s)", i, test.fieldConstraint)
-				err := db.Exec(ctx, q)
+				ctx := context.Background()
+
+				db, err := genji.Open(ctx, ":memory:")
+				require.NoError(t, err)
+				defer db.Close()
+
+				q := fmt.Sprintf("CREATE TABLE test (a %s)", test.fieldConstraint)
+				err = db.Exec(ctx, q)
 				require.NoError(t, err)
 
-				q = fmt.Sprintf("INSERT INTO test%d VALUES %s", i, test.value)
+				q = fmt.Sprintf("INSERT INTO test VALUES %s", test.value)
 				err = db.Exec(ctx, q)
 				require.Error(t, err)
 			})

--- a/sql/query/insert_test.go
+++ b/sql/query/insert_test.go
@@ -44,8 +44,7 @@ func TestInsertStmt(t *testing.T) {
 	for _, test := range tests {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
-				ctx := context.Background()
-				db, err := genji.Open(ctx, ":memory:")
+				db, err := genji.Open(context.Background(), ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
 
@@ -71,7 +70,7 @@ func TestInsertStmt(t *testing.T) {
 				defer st.Close()
 
 				var buf bytes.Buffer
-				err = document.IteratorToJSON(ctx, &buf, st)
+				err = document.IteratorToJSON(&buf, st)
 				require.NoError(t, err)
 				require.JSONEq(t, test.expected, buf.String())
 			}
@@ -111,8 +110,7 @@ func TestInsertStmt(t *testing.T) {
 	})
 
 	t.Run("with struct param", func(t *testing.T) {
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -131,15 +129,14 @@ func TestInsertStmt(t *testing.T) {
 
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		err = document.IteratorToJSON(ctx, &buf, res)
+		err = document.IteratorToJSON(&buf, res)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"a": "a", "b-b": "b"}`, buf.String())
 	})
 
 	t.Run("with types constraints", func(t *testing.T) {
 		// This test ensures that we can insert data into every supported types.
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -164,7 +161,7 @@ func TestInsertStmt(t *testing.T) {
 		require.NoError(t, err)
 
 		var buf bytes.Buffer
-		err = document.IteratorToJSON(ctx, &buf, res)
+		err = document.IteratorToJSON(&buf, res)
 		require.NoError(t, err)
 		require.JSONEq(t, `{
 			"i": 10000000000,

--- a/sql/query/query.go
+++ b/sql/query/query.go
@@ -32,7 +32,7 @@ func (q Query) Run(ctx context.Context, db *database.Database, args []expr.Param
 	}
 
 	type queryAlterer interface {
-		alterQuery(db *database.Database, q *Query) error
+		alterQuery(ctx context.Context, db *database.Database, q *Query) error
 	}
 
 	for i, stmt := range q.Statements {
@@ -43,7 +43,7 @@ func (q Query) Run(ctx context.Context, db *database.Database, args []expr.Param
 		}
 
 		if qa, ok := stmt.(queryAlterer); ok {
-			err = qa.alterQuery(db, &q)
+			err = qa.alterQuery(ctx, db, &q)
 			if err != nil {
 				if tx := db.GetAttachedTx(); tx != nil {
 					tx.Rollback()
@@ -55,7 +55,7 @@ func (q Query) Run(ctx context.Context, db *database.Database, args []expr.Param
 		}
 
 		if q.tx == nil {
-			q.tx, err = db.Begin(!stmt.IsReadOnly())
+			q.tx, err = db.Begin(ctx, !stmt.IsReadOnly())
 			if err != nil {
 				return nil, err
 			}

--- a/sql/query/reindex.go
+++ b/sql/query/reindex.go
@@ -23,17 +23,17 @@ func (stmt ReIndexStmt) Run(ctx context.Context, tx *database.Transaction, args 
 	var res Result
 
 	if stmt.TableOrIndexName == "" {
-		return res, tx.ReIndexAll()
+		return res, tx.ReIndexAll(ctx)
 	}
 
-	t, err := tx.GetTable(stmt.TableOrIndexName)
+	t, err := tx.GetTable(ctx, stmt.TableOrIndexName)
 	if err == nil {
-		return res, t.ReIndex()
+		return res, t.ReIndex(ctx)
 	}
 	if err != database.ErrTableNotFound {
 		return res, err
 	}
 
-	err = tx.ReIndex(stmt.TableOrIndexName)
+	err = tx.ReIndex(ctx, stmt.TableOrIndexName)
 	return res, err
 }

--- a/sql/query/reindex_test.go
+++ b/sql/query/reindex_test.go
@@ -27,7 +27,7 @@ func TestReIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -52,12 +52,12 @@ func TestReIndex(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			err = db.View(func(tx *genji.Tx) error {
-				idxList, err := tx.ListIndexes()
+			err = db.View(ctx, func(tx *genji.Tx) error {
+				idxList, err := tx.ListIndexes(ctx)
 				require.NoError(t, err)
 
 				for _, cfg := range idxList {
-					idx, err := tx.GetIndex(cfg.IndexName)
+					idx, err := tx.GetIndex(ctx, cfg.IndexName)
 					require.NoError(t, err)
 
 					shouldBeIndexed := false
@@ -69,7 +69,7 @@ func TestReIndex(t *testing.T) {
 					}
 
 					i := 0
-					err = idx.AscendGreaterOrEqual(document.Value{}, func(val []byte, key []byte, isEqual bool) error {
+					err = idx.AscendGreaterOrEqual(ctx, document.Value{}, func(val []byte, key []byte, isEqual bool) error {
 						i++
 						return nil
 					})

--- a/sql/query/reindex_test.go
+++ b/sql/query/reindex_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestReIndex(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name            string
 		query           string
@@ -27,6 +25,8 @@ func TestReIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()

--- a/sql/query/reindex_test.go
+++ b/sql/query/reindex_test.go
@@ -26,12 +26,11 @@ func TestReIndex(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 				CREATE TABLE test1;
 				CREATE TABLE test2;
 
@@ -45,14 +44,14 @@ func TestReIndex(t *testing.T) {
 			`)
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query)
+			err = db.Exec(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			err = db.View(ctx, func(tx *genji.Tx) error {
+			err = db.View(func(tx *genji.Tx) error {
 				idxList, err := tx.ListIndexes(ctx)
 				require.NoError(t, err)
 

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -93,7 +93,7 @@ func TestSelectStmt(t *testing.T) {
 	for _, test := range tests {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
-				db, err := genji.Open(":memory:")
+				db, err := genji.Open(ctx, ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
 
@@ -126,7 +126,7 @@ func TestSelectStmt(t *testing.T) {
 				require.NoError(t, err)
 
 				var buf bytes.Buffer
-				err = document.IteratorToJSONArray(&buf, st)
+				err = document.IteratorToJSONArray(ctx, &buf, st)
 				require.NoError(t, err)
 				require.JSONEq(t, test.expected, buf.String())
 			}
@@ -136,7 +136,7 @@ func TestSelectStmt(t *testing.T) {
 	}
 
 	t.Run("with primary key only", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -154,13 +154,13 @@ func TestSelectStmt(t *testing.T) {
 		defer st.Close()
 
 		var buf bytes.Buffer
-		err = document.IteratorToJSONArray(&buf, st)
+		err = document.IteratorToJSONArray(ctx, &buf, st)
 		require.NoError(t, err)
 		require.JSONEq(t, `[{"foo": 2, "bar": "b"},{"foo": 3, "bar": "c"},{"foo": 4, "bar": "d"}]`, buf.String())
 	})
 
 	t.Run("with documents", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -176,7 +176,7 @@ func TestSelectStmt(t *testing.T) {
 			defer st.Close()
 
 			var i int
-			err = st.Iterate(func(d document.Document) error {
+			err = st.Iterate(ctx, func(d document.Document) error {
 				data, err := document.MarshalJSON(d)
 				require.NoError(t, err)
 				require.JSONEq(t, res[i], string(data))
@@ -193,7 +193,7 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("table not found", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -202,7 +202,7 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("with order by and indexes", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
+		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -217,7 +217,7 @@ func TestSelectStmt(t *testing.T) {
 		defer st.Close()
 
 		var buf bytes.Buffer
-		err = document.IteratorToJSONArray(&buf, st)
+		err = document.IteratorToJSONArray(ctx, &buf, st)
 		require.NoError(t, err)
 		require.JSONEq(t, `[{"foo": true},{"foo": 1}, {"foo": 2},{"foo": "hello"}]`, buf.String())
 	})

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -92,15 +92,14 @@ func TestSelectStmt(t *testing.T) {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
 				ctx := context.Background()
-
 				db, err := genji.Open(ctx, ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
 
-				err = db.Exec(ctx, "CREATE TABLE test (k INTEGER PRIMARY KEY)")
+				err = db.Exec("CREATE TABLE test (k INTEGER PRIMARY KEY)")
 				require.NoError(t, err)
 				if withIndexes {
-					err = db.Exec(ctx, `
+					err = db.Exec(`
 						CREATE INDEX idx_color ON test (color);
 						CREATE INDEX idx_size ON test (size);
 						CREATE INDEX idx_shape ON test (shape);
@@ -110,14 +109,14 @@ func TestSelectStmt(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				err = db.Exec(ctx, "INSERT INTO test (k, color, size, shape) VALUES (1, 'red', 10, 'square')")
+				err = db.Exec("INSERT INTO test (k, color, size, shape) VALUES (1, 'red', 10, 'square')")
 				require.NoError(t, err)
-				err = db.Exec(ctx, "INSERT INTO test (k, color, size, weight) VALUES (2, 'blue', 10, 100)")
+				err = db.Exec("INSERT INTO test (k, color, size, weight) VALUES (2, 'blue', 10, 100)")
 				require.NoError(t, err)
-				err = db.Exec(ctx, "INSERT INTO test (k, height, weight) VALUES (3, 100, 200)")
+				err = db.Exec("INSERT INTO test (k, height, weight) VALUES (3, 100, 200)")
 				require.NoError(t, err)
 
-				st, err := db.Query(ctx, test.query, test.params...)
+				st, err := db.Query(test.query, test.params...)
 				defer st.Close()
 				if test.fails {
 					require.Error(t, err)
@@ -137,21 +136,20 @@ func TestSelectStmt(t *testing.T) {
 
 	t.Run("with primary key only", func(t *testing.T) {
 		ctx := context.Background()
-
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "CREATE TABLE test (foo INTEGER PRIMARY KEY)")
+		err = db.Exec("CREATE TABLE test (foo INTEGER PRIMARY KEY)")
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (1, 'a')`)
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (2, 'b')`)
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (3, 'c')`)
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (4, 'd')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (1, 'a')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (2, 'b')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (3, 'c')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (4, 'd')`)
 		require.NoError(t, err)
 
-		st, err := db.Query(ctx, "SELECT * FROM test WHERE foo < 400 AND foo >= 2")
+		st, err := db.Query("SELECT * FROM test WHERE foo < 400 AND foo >= 2")
 		require.NoError(t, err)
 		defer st.Close()
 
@@ -163,19 +161,18 @@ func TestSelectStmt(t *testing.T) {
 
 	t.Run("with documents", func(t *testing.T) {
 		ctx := context.Background()
-
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "CREATE TABLE test")
+		err = db.Exec("CREATE TABLE test")
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `INSERT INTO test VALUES {a: {b: 1}}, {a: 1}, {a: [1, 2, [8,9]]}`)
+		err = db.Exec(`INSERT INTO test VALUES {a: {b: 1}}, {a: 1}, {a: [1, 2, [8,9]]}`)
 		require.NoError(t, err)
 
 		call := func(q string, res ...string) {
-			st, err := db.Query(ctx, q)
+			st, err := db.Query(q)
 			require.NoError(t, err)
 			defer st.Close()
 
@@ -197,30 +194,27 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("table not found", func(t *testing.T) {
-		ctx := context.Background()
-
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "SELECT * FROM foo")
+		err = db.Exec("SELECT * FROM foo")
 		require.Error(t, err)
 	})
 
 	t.Run("with order by and indexes", func(t *testing.T) {
 		ctx := context.Background()
-
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "CREATE TABLE test; CREATE INDEX idx_foo ON test(foo);")
+		err = db.Exec("CREATE TABLE test; CREATE INDEX idx_foo ON test(foo);")
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `INSERT INTO test (foo) VALUES (1), ('hello'), (2), (true)`)
+		err = db.Exec(`INSERT INTO test (foo) VALUES (1), ('hello'), (2), (true)`)
 		require.NoError(t, err)
 
-		st, err := db.Query(ctx, "SELECT * FROM test ORDER BY foo")
+		st, err := db.Query("SELECT * FROM test ORDER BY foo")
 		require.NoError(t, err)
 		defer st.Close()
 

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestSelectStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -93,6 +91,8 @@ func TestSelectStmt(t *testing.T) {
 	for _, test := range tests {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
+				ctx := context.Background()
+
 				db, err := genji.Open(ctx, ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
@@ -136,6 +136,8 @@ func TestSelectStmt(t *testing.T) {
 	}
 
 	t.Run("with primary key only", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
@@ -160,6 +162,8 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("with documents", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
@@ -193,6 +197,8 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("table not found", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
@@ -202,6 +208,8 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("with order by and indexes", func(t *testing.T) {
+		ctx := context.Background()
+
 		db, err := genji.Open(ctx, ":memory:")
 		require.NoError(t, err)
 		defer db.Close()

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -91,8 +91,7 @@ func TestSelectStmt(t *testing.T) {
 	for _, test := range tests {
 		testFn := func(withIndexes bool) func(t *testing.T) {
 			return func(t *testing.T) {
-				ctx := context.Background()
-				db, err := genji.Open(ctx, ":memory:")
+				db, err := genji.Open(context.Background(), ":memory:")
 				require.NoError(t, err)
 				defer db.Close()
 
@@ -125,7 +124,7 @@ func TestSelectStmt(t *testing.T) {
 				require.NoError(t, err)
 
 				var buf bytes.Buffer
-				err = document.IteratorToJSONArray(ctx, &buf, st)
+				err = document.IteratorToJSONArray(&buf, st)
 				require.NoError(t, err)
 				require.JSONEq(t, test.expected, buf.String())
 			}
@@ -135,8 +134,7 @@ func TestSelectStmt(t *testing.T) {
 	}
 
 	t.Run("with primary key only", func(t *testing.T) {
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -154,14 +152,13 @@ func TestSelectStmt(t *testing.T) {
 		defer st.Close()
 
 		var buf bytes.Buffer
-		err = document.IteratorToJSONArray(ctx, &buf, st)
+		err = document.IteratorToJSONArray(&buf, st)
 		require.NoError(t, err)
 		require.JSONEq(t, `[{"foo": 2, "bar": "b"},{"foo": 3, "bar": "c"},{"foo": 4, "bar": "d"}]`, buf.String())
 	})
 
 	t.Run("with documents", func(t *testing.T) {
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -177,7 +174,7 @@ func TestSelectStmt(t *testing.T) {
 			defer st.Close()
 
 			var i int
-			err = st.Iterate(ctx, func(d document.Document) error {
+			err = st.Iterate(func(d document.Document) error {
 				data, err := document.MarshalJSON(d)
 				require.NoError(t, err)
 				require.JSONEq(t, res[i], string(data))
@@ -203,8 +200,7 @@ func TestSelectStmt(t *testing.T) {
 	})
 
 	t.Run("with order by and indexes", func(t *testing.T) {
-		ctx := context.Background()
-		db, err := genji.Open(ctx, ":memory:")
+		db, err := genji.Open(context.Background(), ":memory:")
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -219,7 +215,7 @@ func TestSelectStmt(t *testing.T) {
 		defer st.Close()
 
 		var buf bytes.Buffer
-		err = document.IteratorToJSONArray(ctx, &buf, st)
+		err = document.IteratorToJSONArray(&buf, st)
 		require.NoError(t, err)
 		require.JSONEq(t, `[{"foo": true},{"foo": 1}, {"foo": 2},{"foo": "hello"}]`, buf.String())
 	})

--- a/sql/query/transaction.go
+++ b/sql/query/transaction.go
@@ -13,13 +13,13 @@ type BeginStmt struct {
 	Writable bool
 }
 
-func (stmt BeginStmt) alterQuery(db *database.Database, q *Query) error {
+func (stmt BeginStmt) alterQuery(ctx context.Context, db *database.Database, q *Query) error {
 	if q.tx != nil {
 		return errors.New("cannot begin a transaction within a transaction")
 	}
 
 	var err error
-	q.tx, err = db.BeginTx(&database.TxOptions{
+	q.tx, err = db.BeginTx(ctx, &database.TxOptions{
 		ReadOnly: !stmt.Writable,
 		Attached: true,
 	})
@@ -38,7 +38,7 @@ func (stmt BeginStmt) Run(ctx context.Context, tx *database.Transaction, args []
 // RollbackStmt is a statement that rollbacks the current active transaction.
 type RollbackStmt struct{}
 
-func (stmt RollbackStmt) alterQuery(db *database.Database, q *Query) error {
+func (stmt RollbackStmt) alterQuery(ctx context.Context, db *database.Database, q *Query) error {
 	if q.tx == nil || q.autoCommit == true {
 		return errors.New("cannot rollback with no active transaction")
 	}
@@ -62,7 +62,7 @@ func (stmt RollbackStmt) Run(ctx context.Context, tx *database.Transaction, args
 // CommitStmt is a statement that commits the current active transaction.
 type CommitStmt struct{}
 
-func (stmt CommitStmt) alterQuery(db *database.Database, q *Query) error {
+func (stmt CommitStmt) alterQuery(ctx context.Context, db *database.Database, q *Query) error {
 	if q.tx == nil || q.autoCommit == true {
 		return errors.New("cannot commit with no active transaction")
 	}

--- a/sql/query/transaction_test.go
+++ b/sql/query/transaction_test.go
@@ -28,15 +28,13 @@ func TestTransactionRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
-			defer db.Exec(ctx, "ROLLBACK")
+			defer db.Exec("ROLLBACK")
 
 			for _, q := range test.queries {
-				err = db.Exec(ctx, q)
+				err = db.Exec(q)
 				if err != nil {
 					break
 				}

--- a/sql/query/transaction_test.go
+++ b/sql/query/transaction_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestTransactionRun(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name    string
 		queries []string
@@ -30,6 +28,8 @@ func TestTransactionRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()

--- a/sql/query/transaction_test.go
+++ b/sql/query/transaction_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestTransactionRun(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		name    string
 		queries []string
@@ -28,9 +30,7 @@ func TestTransactionRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 			defer db.Exec(ctx, "ROLLBACK")

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -46,28 +46,27 @@ func TestUpdateStmt(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test (a text not null)")
+			err = db.Exec("CREATE TABLE test (a text not null)")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
+			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
+			err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query, test.params...)
+			err = db.Exec(test.query, test.params...)
 			if test.fails {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			st, err := db.Query(ctx, "SELECT * FROM test")
+			st, err := db.Query("SELECT * FROM test")
 			require.NoError(t, err)
 			defer st.Close()
 
@@ -100,24 +99,23 @@ func TestUpdateStmt(t *testing.T) {
 
 		for _, tt := range tests {
 			ctx := context.Background()
-
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, `CREATE TABLE foo;`)
+			err = db.Exec(`CREATE TABLE foo;`)
 			require.NoError(t, err)
-			err = db.Exec(ctx, `INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
+			err = db.Exec(`INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, tt.query, tt.params...)
+			err = db.Exec(tt.query, tt.params...)
 			if tt.fails {
 				require.Error(t, err)
 				continue
 			}
 
 			require.NoError(t, err)
-			st, err := db.Query(ctx, "SELECT * FROM foo")
+			st, err := db.Query("SELECT * FROM foo")
 			require.NoError(t, err)
 			defer st.Close()
 

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -47,7 +47,7 @@ func TestUpdateStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -73,7 +73,7 @@ func TestUpdateStmt(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			err = document.IteratorToJSONArray(&buf, st)
+			err = document.IteratorToJSONArray(ctx, &buf, st)
 			require.NoError(t, err)
 			require.JSONEq(t, test.expected, buf.String())
 		})
@@ -99,7 +99,7 @@ func TestUpdateStmt(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			db, err := genji.Open(":memory:")
+			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -121,7 +121,7 @@ func TestUpdateStmt(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			err = document.IteratorToJSONArray(&buf, st)
+			err = document.IteratorToJSONArray(ctx, &buf, st)
 			require.NoError(t, err)
 			require.JSONEq(t, tt.expected, buf.String())
 		}

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestUpdateStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -47,6 +45,8 @@ func TestUpdateStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
@@ -99,6 +99,8 @@ func TestUpdateStmt(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			ctx := context.Background()
+
 			db, err := genji.Open(ctx, ":memory:")
 			require.NoError(t, err)
 			defer db.Close()

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -45,8 +45,7 @@ func TestUpdateStmt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -72,7 +71,7 @@ func TestUpdateStmt(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			err = document.IteratorToJSONArray(ctx, &buf, st)
+			err = document.IteratorToJSONArray(&buf, st)
 			require.NoError(t, err)
 			require.JSONEq(t, test.expected, buf.String())
 		})
@@ -98,8 +97,7 @@ func TestUpdateStmt(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			ctx := context.Background()
-			db, err := genji.Open(ctx, ":memory:")
+			db, err := genji.Open(context.Background(), ":memory:")
 			require.NoError(t, err)
 			defer db.Close()
 
@@ -121,7 +119,7 @@ func TestUpdateStmt(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			err = document.IteratorToJSONArray(ctx, &buf, st)
+			err = document.IteratorToJSONArray(&buf, st)
 			require.NoError(t, err)
 			require.JSONEq(t, tt.expected, buf.String())
 		}


### PR DESCRIPTION
This PR adds `context.Context` support in Genji, starting with the `engine` package and then fixing compile errors everywhere. It doesn’t introduce any cancellation behavior though—that should be a separate, smaller, PR.

- `engine.Iterator` usage now requires a `it.Err()` check after the loop.
  ```
  it := st.Iterator(engine.IteratorOptions{})
  defer it.Close()

  for it.Seek(ctx, nil); it.Valid(); it.Next(ctx) {
  	…
  }
  if err := it.Err(); err != nil {
  	…
  }
  ```

  Notice that `Seek` and `Next` now accept a `context.Context` parameter. If an error occurs, `Valid` returns false.

- `database.Table` no longer directly implements `document.Iterator` since iteration may be I/O bound.

  ```
  // Before
  func (*Table) Iterate(func(d document.Document) error) error
  // After
  func (*Table) Iterator(context.Context) document.IteratorFunc
  func (*Table) Iterate(context.Context, func(d document.Document) error) error
  ```

Closes #224 and #206
