### PR TITLE
Fixes .Indexes and .tables commands error handler and tests

### DIFF
--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -52,15 +52,14 @@ func runTablesCmd(db *genji.DB, cmd []string) error {
 
 // displayTableIndex prints all indexes that the given table contains.
 func displayTableIndex(db *genji.DB, tableName string) error {
-	ctx := context.Background()
 	return db.View(func(tx *genji.Tx) error {
+		ctx := context.Background()
 		_, err := tx.QueryDocument(ctx, "SELECT table_name FROM __genji_tables WHERE table_name = ?", tableName)
-		switch err {
-		case database.ErrDocumentNotFound:
-			return database.ErrTableNotFound
-		case nil:
-			// nop
-		default:
+		if err != nil {
+			if err == database.ErrDocumentNotFound {
+				return database.ErrTableNotFound
+			}
+
 			return err
 		}
 

--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -60,6 +60,11 @@ func displayTableIndex(db *genji.DB, tableName string) error {
 	}
 	defer res.Close()
 
+	_, err = res.Tx.GetTable(tableName)
+	if err != nil {
+		return err
+	}
+
 	return res.Iterate(func(d document.Document) error {
 		var index database.IndexConfig
 

--- a/cmd/genji/shell/command_test.go
+++ b/cmd/genji/shell/command_test.go
@@ -14,17 +14,17 @@ import (
 func TestRunTablesCmd(t *testing.T) {
 	tests := []struct {
 		name    string
-		in      string
+		in      []string
 		wantErr bool
 	}{
 		{
 			"Table",
-			".tables",
+			strings.Fields(".tables"),
 			false,
 		},
 		{
 			"Table with options",
-			".tables test",
+			strings.Fields(".tables test"),
 			true,
 		},
 	}
@@ -34,7 +34,7 @@ func TestRunTablesCmd(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			if err := displayTableIndex(db, test.in); (err != nil) != test.wantErr {
+			if err := runTablesCmd(db, test.in); (err != nil) != test.wantErr {
 				require.Errorf(t, err, "", test.wantErr)
 			}
 		})
@@ -60,7 +60,7 @@ func TestIndexesCmd(t *testing.T) {
 		{
 			"Indexes with nonexistent table name",
 			strings.Fields(".indexes foo"),
-			false,
+			true,
 		},
 	}
 


### PR DESCRIPTION
Fixes #233 

`command_test.go` had some errors.
`.Indexes` returns `table not found`