### PR TITLE
Add ADD COLUMN statement, add DEFAULT field constraint

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -319,13 +319,7 @@ func (t *tableInfoStore) modifyTable(tx *Transaction, tableName string, f func(*
 		return err
 	}
 
-	key := []byte(tableName)
-	err = st.Delete(key)
-	if err != nil {
-		return err
-	}
-
-	err = st.Put(key, buf.Bytes())
+	err = st.Put([]byte(tableName), buf.Bytes())
 	if err != nil {
 		return err
 	}

--- a/database/config.go
+++ b/database/config.go
@@ -18,6 +18,11 @@ type FieldConstraint struct {
 	Type         document.ValueType
 	IsPrimaryKey bool
 	IsNotNull    bool
+	DefaultValue document.Value
+}
+
+func (f *FieldConstraint) HasDefaultValue() bool {
+	return f.DefaultValue.Type != 0
 }
 
 // ToDocument returns a document from f.
@@ -28,6 +33,7 @@ func (f *FieldConstraint) ToDocument() document.Document {
 	buf.Add("type", document.NewIntegerValue(int64(f.Type)))
 	buf.Add("is_primary_key", document.NewBoolValue(f.IsPrimaryKey))
 	buf.Add("is_not_null", document.NewBoolValue(f.IsNotNull))
+	buf.Add("default_value", f.DefaultValue)
 	return buf
 }
 
@@ -60,6 +66,13 @@ func (f *FieldConstraint) ScanDocument(d document.Document) error {
 		return err
 	}
 	f.IsNotNull = v.V.(bool)
+
+	v, err = d.GetByField("default_value")
+	if err != nil {
+		return err
+	}
+	f.DefaultValue = v
+
 	return nil
 }
 
@@ -319,7 +332,7 @@ func (t *tableInfoStore) loadAllTableInfo(tx engine.Transaction) error {
 
 	t.tableInfos[indexStoreName] = TableInfo{
 		storeName: []byte(indexStoreName),
-		readOnly: true,
+		readOnly:  true,
 		FieldConstraints: []FieldConstraint{
 			{
 				Path: document.ValuePath{

--- a/database/config.go
+++ b/database/config.go
@@ -33,7 +33,9 @@ func (f *FieldConstraint) ToDocument() document.Document {
 	buf.Add("type", document.NewIntegerValue(int64(f.Type)))
 	buf.Add("is_primary_key", document.NewBoolValue(f.IsPrimaryKey))
 	buf.Add("is_not_null", document.NewBoolValue(f.IsNotNull))
-	buf.Add("default_value", f.DefaultValue)
+	if f.HasDefaultValue() {
+		buf.Add("default_value", f.DefaultValue)
+	}
 	return buf
 }
 
@@ -68,10 +70,12 @@ func (f *FieldConstraint) ScanDocument(d document.Document) error {
 	f.IsNotNull = v.V.(bool)
 
 	v, err = d.GetByField("default_value")
-	if err != nil {
+	if err != nil && err != document.ErrFieldNotFound {
 		return err
 	}
-	f.DefaultValue = v
+	if err == nil {
+		f.DefaultValue = v
+	}
 
 	return nil
 }
@@ -281,6 +285,53 @@ func (t *tableInfoStore) Delete(tx *Transaction, tableName string) error {
 	}
 
 	delete(t.tableInfos, tableName)
+
+	return nil
+}
+
+// modifyTable modifies TableInfo using given callback.
+func (t *tableInfoStore) modifyTable(tx *Transaction, tableName string, f func(*TableInfo) error) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	info, ok := t.tableInfos[tableName]
+	if !ok {
+		return ErrTableNotFound
+	}
+
+	if info.transactionID != 0 && info.transactionID != tx.id {
+		return ErrTableNotFound
+	}
+
+	err := f(&info)
+	if err != nil {
+		return err
+	}
+
+	st, err := tx.tx.GetStore([]byte(tableInfoStoreName))
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	err = t.db.Codec.NewEncoder(&buf).EncodeDocument(info.ToDocument())
+	if err != nil {
+		return err
+	}
+
+	key := []byte(tableName)
+	err = st.Delete(key)
+	if err != nil {
+		return err
+	}
+
+	err = st.Put(key, buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	info.transactionID = tx.id
+	t.tableInfos[tableName] = info
 
 	return nil
 }

--- a/database/table.go
+++ b/database/table.go
@@ -466,7 +466,11 @@ func validateConstraint(d document.Document, c *FieldConstraint) error {
 		if field.FieldName == "" {
 			// if the field is not found we make sure it is not required
 			if c.IsNotNull {
-				return fmt.Errorf("field %q is required and must be not null", c.Path)
+				if !c.HasDefaultValue() {
+					return fmt.Errorf("field %q is required and must be not null", c.Path)
+				}
+
+				return buf.Set(c.Path, c.DefaultValue)
 			}
 			return nil
 		}
@@ -476,9 +480,12 @@ func validateConstraint(d document.Document, c *FieldConstraint) error {
 		if err != nil {
 			if err == document.ErrFieldNotFound {
 				if c.IsNotNull {
-					return fmt.Errorf("field %q is required and must be not null", c.Path)
-				}
+					if !c.HasDefaultValue() {
+						return fmt.Errorf("field %q is required and must be not null", c.Path)
+					}
 
+					return buf.Set(c.Path, c.DefaultValue)
+				}
 				return nil
 			}
 
@@ -521,9 +528,12 @@ func validateConstraint(d document.Document, c *FieldConstraint) error {
 		if err != nil {
 			if err == document.ErrValueNotFound {
 				if c.IsNotNull {
-					return fmt.Errorf("value %q is required and must be not null", c.Path)
-				}
+					if !c.HasDefaultValue() {
+						return fmt.Errorf("field %q is required and must be not null", c.Path)
+					}
 
+					return buf.Copy(c.DefaultValue.V.(document.Array))
+				}
 				return nil
 			}
 

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -128,32 +128,8 @@ func (tx *Transaction) GetTable(name string) (*Table, error) {
 	}, nil
 }
 
-// modifyTable modifies TableInfo using given callback.
-func (tx *Transaction) modifyTable(name string, f func(*TableInfo) error) error {
-	ti, err := tx.tableInfoStore.Get(tx, name)
-	if err != nil {
-		return err
-	}
-
-	if ti.readOnly {
-		return errors.New("cannot write to read-only table")
-	}
-
-	err = tx.tableInfoStore.Delete(tx, name)
-	if err != nil {
-		return err
-	}
-
-	err = f(ti)
-	if err != nil {
-		return err
-	}
-
-	return tx.tableInfoStore.Insert(tx, name, ti)
-}
-
 func (tx *Transaction) AddField(name string, fc FieldConstraint) error {
-	return tx.modifyTable(name, func(info *TableInfo) error {
+	return tx.tableInfoStore.modifyTable(tx, name, func(info *TableInfo) error {
 		for _, field := range info.FieldConstraints {
 			if field.Path.IsEqual(fc.Path) {
 				return fmt.Errorf("field %q already exists", fc.Path.String())

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -152,7 +152,7 @@ func (tx *Transaction) modifyTable(name string, f func(*TableInfo) error) error 
 	return tx.tableInfoStore.Insert(tx, name, ti)
 }
 
-func (tx *Transaction) AddColumn(name string, fc FieldConstraint) error {
+func (tx *Transaction) AddField(name string, fc FieldConstraint) error {
 	return tx.modifyTable(name, func(info *TableInfo) error {
 		for _, field := range info.FieldConstraints {
 			if field.Path.IsEqual(fc.Path) {

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -28,7 +28,7 @@ func newTestDB(t testing.TB) (*database.Transaction, func()) {
 // - GetTable
 // - DropTable
 // - RenameTable
-// - AddColumn
+// - AddField
 func TestTxTable(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
 		tx, cleanup := newTestDB(t)
@@ -148,7 +148,7 @@ func TestTxTable(t *testing.T) {
 		require.EqualError(t, database.ErrTableNotFound, err.Error())
 	})
 
-	t.Run("Add column", func(t *testing.T) {
+	t.Run("Add field", func(t *testing.T) {
 		tx, cleanup := newTestDB(t)
 		defer cleanup()
 
@@ -161,11 +161,11 @@ func TestTxTable(t *testing.T) {
 		err := tx.CreateTable("foo", ti)
 		require.NoError(t, err)
 
-		// Add column
-		columnToAdd := database.FieldConstraint{
+		// Add field
+		fieldToAdd := database.FieldConstraint{
 			Path: parsePath(t, "last_name"), Type: document.TextValue,
 		}
-		err = tx.AddColumn("foo", columnToAdd)
+		err = tx.AddField("foo", fieldToAdd)
 		require.NoError(t, err)
 
 		tb, err := tx.GetTable("foo")
@@ -174,21 +174,21 @@ func TestTxTable(t *testing.T) {
 		// The field constraints should not be the same.
 		info, err := tb.Info()
 		require.NoError(t, err)
-		require.Contains(t, info.FieldConstraints, columnToAdd)
+		require.Contains(t, info.FieldConstraints, fieldToAdd)
 
 		// Renaming a non existing table should return an error
-		err = tx.AddColumn("bar", columnToAdd)
+		err = tx.AddField("bar", fieldToAdd)
 		require.EqualError(t, database.ErrTableNotFound, err.Error())
 
 		// Adding a existing field should return an error
-		err = tx.AddColumn("foo", ti.FieldConstraints[0])
+		err = tx.AddField("foo", ti.FieldConstraints[0])
 		require.Error(t, err)
 
 		// Adding a second primary key should return an error
-		columnToAdd = database.FieldConstraint{
+		fieldToAdd = database.FieldConstraint{
 			Path: parsePath(t, "foobar"), Type: document.IntegerValue, IsPrimaryKey: true,
 		}
-		err = tx.AddColumn("foo", columnToAdd)
+		err = tx.AddField("foo", fieldToAdd)
 		require.Error(t, err)
 	})
 }

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -28,6 +28,7 @@ func newTestDB(t testing.TB) (*database.Transaction, func()) {
 // - GetTable
 // - DropTable
 // - RenameTable
+// - AddColumn
 func TestTxTable(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
 		tx, cleanup := newTestDB(t)
@@ -145,6 +146,50 @@ func TestTxTable(t *testing.T) {
 		// Renaming a non existing table should return an error
 		err = tx.RenameTable("foo", "")
 		require.EqualError(t, database.ErrTableNotFound, err.Error())
+	})
+
+	t.Run("Add column", func(t *testing.T) {
+		tx, cleanup := newTestDB(t)
+		defer cleanup()
+
+		ti := &database.TableInfo{FieldConstraints: []database.FieldConstraint{
+			{Path: parsePath(t, "name"), Type: document.TextValue, IsNotNull: true},
+			{Path: parsePath(t, "age"), Type: document.IntegerValue, IsPrimaryKey: true},
+			{Path: parsePath(t, "gender"), Type: document.TextValue},
+			{Path: parsePath(t, "city"), Type: document.TextValue},
+		}}
+		err := tx.CreateTable("foo", ti)
+		require.NoError(t, err)
+
+		// Add column
+		columnToAdd := database.FieldConstraint{
+			Path: parsePath(t, "last_name"), Type: document.TextValue,
+		}
+		err = tx.AddColumn("foo", columnToAdd)
+		require.NoError(t, err)
+
+		tb, err := tx.GetTable("foo")
+		require.NoError(t, err)
+
+		// The field constraints should not be the same.
+		info, err := tb.Info()
+		require.NoError(t, err)
+		require.Contains(t, info.FieldConstraints, columnToAdd)
+
+		// Renaming a non existing table should return an error
+		err = tx.AddColumn("bar", columnToAdd)
+		require.EqualError(t, database.ErrTableNotFound, err.Error())
+
+		// Adding a existing field should return an error
+		err = tx.AddColumn("foo", ti.FieldConstraints[0])
+		require.Error(t, err)
+
+		// Adding a second primary key should return an error
+		columnToAdd = database.FieldConstraint{
+			Path: parsePath(t, "foobar"), Type: document.IntegerValue, IsPrimaryKey: true,
+		}
+		err = tx.AddColumn("foo", columnToAdd)
+		require.Error(t, err)
 	})
 }
 

--- a/sql/parser/alter.go
+++ b/sql/parser/alter.go
@@ -27,13 +27,13 @@ func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.Alt
 	var stmt query.AlterTableAddField
 	stmt.TableName = tableName
 
-	// Parse "COLUMN" or "FIELD".
-	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.COLUMN && tok != scanner.FIELD {
-		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"COLUMN", "FIELD"}, pos)
+	// Parse "FIELD".
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.FIELD {
+		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"FIELD"}, pos)
 	}
 
 	// Parse new field definition.
-	err = p.parseField(&stmt.Constraint)
+	err = p.parseFieldDefinition(&stmt.Constraint)
 	if err != nil {
 		return stmt, err
 	}

--- a/sql/parser/alter.go
+++ b/sql/parser/alter.go
@@ -38,6 +38,10 @@ func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.Alt
 		return stmt, err
 	}
 
+	if stmt.Constraint.IsPrimaryKey {
+		return stmt, &ParseError{Message: "Adding a field with primary key constraint is not supported now."}
+	}
+
 	return stmt, nil
 }
 

--- a/sql/parser/alter.go
+++ b/sql/parser/alter.go
@@ -5,29 +5,9 @@ import (
 	"github.com/genjidb/genji/sql/scanner"
 )
 
-// parseAlterStatement parses a Alter query string and returns a Statement AST object.
-// This function assumes the ALTER token has already been consumed.
-func (p *Parser) parseAlterStatement() (query.AlterStmt, error) {
+func (p *Parser) parseAlterTableRenameStatement(tableName string) (_ query.AlterStmt, err error) {
 	var stmt query.AlterStmt
-	var err error
-
-	// Parse "TABLE".
-	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.TABLE {
-		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"TABLE"}, pos)
-	}
-
-	// Parse table name.
-	stmt.TableName, err = p.parseIdent()
-	if err != nil {
-		pErr := err.(*ParseError)
-		pErr.Expected = []string{"table_name"}
-		return stmt, pErr
-	}
-
-	// Parse "RENAME".
-	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.RENAME {
-		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"RENAME"}, pos)
-	}
+	stmt.TableName = tableName
 
 	// Parse "TO".
 	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.TO {
@@ -41,4 +21,51 @@ func (p *Parser) parseAlterStatement() (query.AlterStmt, error) {
 	}
 
 	return stmt, nil
+}
+
+func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.AlterTableAddColumn, err error) {
+	var stmt query.AlterTableAddColumn
+	stmt.TableName = tableName
+
+	// Parse "COLUMN".
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.COLUMN {
+		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"COLUMN"}, pos)
+	}
+
+	// Parse new column(field) definition.
+	err = p.parseField(&stmt.Constraint)
+	if err != nil {
+		return stmt, err
+	}
+
+	return stmt, nil
+}
+
+// parseAlterStatement parses a Alter query string and returns a Statement AST object.
+// This function assumes the ALTER token has already been consumed.
+func (p *Parser) parseAlterStatement() (query.Statement, error) {
+	var err error
+
+	// Parse "TABLE".
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.TABLE {
+		return nil, newParseError(scanner.Tokstr(tok, lit), []string{"TABLE"}, pos)
+	}
+
+	// Parse table name.
+	tableName, err := p.parseIdent()
+	if err != nil {
+		pErr := err.(*ParseError)
+		pErr.Expected = []string{"table_name"}
+		return nil, pErr
+	}
+
+	tok, pos, lit := p.ScanIgnoreWhitespace()
+	switch tok {
+	case scanner.RENAME:
+		return p.parseAlterTableRenameStatement(tableName)
+	case scanner.ADD_KEYWORD:
+		return p.parseAlterTableAddFieldStatement(tableName)
+	}
+
+	return nil, newParseError(scanner.Tokstr(tok, lit), []string{"ADD", "RENAME"}, pos)
 }

--- a/sql/parser/alter.go
+++ b/sql/parser/alter.go
@@ -39,7 +39,7 @@ func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.Alt
 	}
 
 	if stmt.Constraint.IsPrimaryKey {
-		return stmt, &ParseError{Message: "Adding a field with primary key constraint is not supported now."}
+		return stmt, &ParseError{Message: "cannot add a PRIMARY KEY constraint"}
 	}
 
 	return stmt, nil

--- a/sql/parser/alter.go
+++ b/sql/parser/alter.go
@@ -27,12 +27,12 @@ func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.Alt
 	var stmt query.AlterTableAddColumn
 	stmt.TableName = tableName
 
-	// Parse "COLUMN".
-	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.COLUMN {
-		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"COLUMN"}, pos)
+	// Parse "COLUMN" or "FIELD".
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.COLUMN && tok != scanner.FIELD {
+		return stmt, newParseError(scanner.Tokstr(tok, lit), []string{"COLUMN", "FIELD"}, pos)
 	}
 
-	// Parse new column(field) definition.
+	// Parse new field definition.
 	err = p.parseField(&stmt.Constraint)
 	if err != nil {
 		return stmt, err

--- a/sql/parser/alter.go
+++ b/sql/parser/alter.go
@@ -23,8 +23,8 @@ func (p *Parser) parseAlterTableRenameStatement(tableName string) (_ query.Alter
 	return stmt, nil
 }
 
-func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.AlterTableAddColumn, err error) {
-	var stmt query.AlterTableAddColumn
+func (p *Parser) parseAlterTableAddFieldStatement(tableName string) (_ query.AlterTableAddField, err error) {
+	var stmt query.AlterTableAddField
 	stmt.TableName = tableName
 
 	// Parse "COLUMN" or "FIELD".

--- a/sql/parser/alter_test.go
+++ b/sql/parser/alter_test.go
@@ -44,35 +44,30 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 		expected query.Statement
 		errored  bool
 	}{
-		{"Basic", "ALTER TABLE foo ADD COLUMN bar", query.AlterTableAddField{TableName: "foo",
+		{"Basic", "ALTER TABLE foo ADD FIELD bar", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path: parsePath(t, "bar"),
 			},
 		}, false},
-		{"FIELD instead of COLUMN", "ALTER TABLE foo ADD FIELD bar", query.AlterTableAddField{TableName: "foo",
-			Constraint: database.FieldConstraint{
-				Path: parsePath(t, "bar"),
-			},
-		}, false},
-		{"With type", "ALTER TABLE foo ADD COLUMN bar integer", query.AlterTableAddField{TableName: "foo",
+		{"With type", "ALTER TABLE foo ADD FIELD bar integer", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path: parsePath(t, "bar"),
 				Type: document.IntegerValue,
 			},
 		}, false},
-		{"With not null", "ALTER TABLE foo ADD COLUMN bar NOT NULL", query.AlterTableAddField{TableName: "foo",
+		{"With not null", "ALTER TABLE foo ADD FIELD bar NOT NULL", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:      parsePath(t, "bar"),
 				IsNotNull: true,
 			},
 		}, false},
-		{"With primary key", "ALTER TABLE foo ADD COLUMN bar PRIMARY KEY", query.AlterTableAddField{TableName: "foo",
+		{"With primary key", "ALTER TABLE foo ADD FIELD bar PRIMARY KEY", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:         parsePath(t, "bar"),
 				IsPrimaryKey: true,
 			},
 		}, false},
-		{"With multiple constraints", "ALTER TABLE foo ADD COLUMN bar integer NOT NULL DEFAULT 0", query.AlterTableAddField{TableName: "foo",
+		{"With multiple constraints", "ALTER TABLE foo ADD FIELD bar integer NOT NULL DEFAULT 0", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:         parsePath(t, "bar"),
 				Type:         document.IntegerValue,
@@ -80,7 +75,7 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 				DefaultValue: document.NewIntegerValue(0),
 			},
 		}, false},
-		{"With error / missing COLUMN or FIELD keyword", "ALTER TABLE foo ADD bar", nil, true},
+		{"With error / missing FIELD keyword", "ALTER TABLE foo ADD bar", nil, true},
 		{"With error / missing field name", "ALTER TABLE foo ADD FIELD", nil, true},
 	}
 

--- a/sql/parser/alter_test.go
+++ b/sql/parser/alter_test.go
@@ -44,35 +44,35 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 		expected query.Statement
 		errored  bool
 	}{
-		{"Basic", "ALTER TABLE foo ADD COLUMN bar", query.AlterTableAddColumn{TableName: "foo",
+		{"Basic", "ALTER TABLE foo ADD COLUMN bar", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path: parsePath(t, "bar"),
 			},
 		}, false},
-		{"FIELD instead of COLUMN", "ALTER TABLE foo ADD FIELD bar", query.AlterTableAddColumn{TableName: "foo",
+		{"FIELD instead of COLUMN", "ALTER TABLE foo ADD FIELD bar", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path: parsePath(t, "bar"),
 			},
 		}, false},
-		{"With type", "ALTER TABLE foo ADD COLUMN bar integer", query.AlterTableAddColumn{TableName: "foo",
+		{"With type", "ALTER TABLE foo ADD COLUMN bar integer", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path: parsePath(t, "bar"),
 				Type: document.IntegerValue,
 			},
 		}, false},
-		{"With not null", "ALTER TABLE foo ADD COLUMN bar NOT NULL", query.AlterTableAddColumn{TableName: "foo",
+		{"With not null", "ALTER TABLE foo ADD COLUMN bar NOT NULL", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:      parsePath(t, "bar"),
 				IsNotNull: true,
 			},
 		}, false},
-		{"With primary key", "ALTER TABLE foo ADD COLUMN bar PRIMARY KEY", query.AlterTableAddColumn{TableName: "foo",
+		{"With primary key", "ALTER TABLE foo ADD COLUMN bar PRIMARY KEY", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:         parsePath(t, "bar"),
 				IsPrimaryKey: true,
 			},
 		}, false},
-		{"With multiple constraints", "ALTER TABLE foo ADD COLUMN bar integer NOT NULL DEFAULT 0", query.AlterTableAddColumn{TableName: "foo",
+		{"With multiple constraints", "ALTER TABLE foo ADD COLUMN bar integer NOT NULL DEFAULT 0", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:         parsePath(t, "bar"),
 				Type:         document.IntegerValue,

--- a/sql/parser/alter_test.go
+++ b/sql/parser/alter_test.go
@@ -61,12 +61,7 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 				IsNotNull: true,
 			},
 		}, false},
-		{"With primary key", "ALTER TABLE foo ADD FIELD bar PRIMARY KEY", query.AlterTableAddField{TableName: "foo",
-			Constraint: database.FieldConstraint{
-				Path:         parsePath(t, "bar"),
-				IsPrimaryKey: true,
-			},
-		}, false},
+		{"With primary key", "ALTER TABLE foo ADD FIELD bar PRIMARY KEY", query.AlterTableAddField{}, true},
 		{"With multiple constraints", "ALTER TABLE foo ADD FIELD bar integer NOT NULL DEFAULT 0", query.AlterTableAddField{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path:         parsePath(t, "bar"),

--- a/sql/parser/alter_test.go
+++ b/sql/parser/alter_test.go
@@ -49,6 +49,11 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 				Path: parsePath(t, "bar"),
 			},
 		}, false},
+		{"FIELD instead of COLUMN", "ALTER TABLE foo ADD FIELD bar", query.AlterTableAddColumn{TableName: "foo",
+			Constraint: database.FieldConstraint{
+				Path: parsePath(t, "bar"),
+			},
+		}, false},
 		{"With type", "ALTER TABLE foo ADD COLUMN bar integer", query.AlterTableAddColumn{TableName: "foo",
 			Constraint: database.FieldConstraint{
 				Path: parsePath(t, "bar"),
@@ -75,6 +80,8 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 				DefaultValue: document.NewIntegerValue(0),
 			},
 		}, false},
+		{"With error / missing COLUMN or FIELD keyword", "ALTER TABLE foo ADD bar", nil, true},
+		{"With error / missing field name", "ALTER TABLE foo ADD FIELD", nil, true},
 	}
 
 	for _, test := range tests {

--- a/sql/parser/alter_test.go
+++ b/sql/parser/alter_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/genjidb/genji/database"
+	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/sql/query"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +21,60 @@ func TestParserAlterTable(t *testing.T) {
 		{"With error / missing TABLE keyword", "ALTER foo RENAME TO bar", query.AlterStmt{}, true},
 		{"With error / two identifiers for table name", "ALTER TABLE foo baz RENAME TO bar", query.AlterStmt{}, true},
 		{"With error / two identifiers for new table name", "ALTER TABLE foo RENAME TO bar baz", query.AlterStmt{}, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q, err := ParseQuery(context.Background(), test.s)
+			if test.errored {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, q.Statements, 1)
+			require.EqualValues(t, test.expected, q.Statements[0])
+		})
+	}
+}
+
+func TestParserAlterTableAddColumn(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		expected query.Statement
+		errored  bool
+	}{
+		{"Basic", "ALTER TABLE foo ADD COLUMN bar", query.AlterTableAddColumn{TableName: "foo",
+			Constraint: database.FieldConstraint{
+				Path: parsePath(t, "bar"),
+			},
+		}, false},
+		{"With type", "ALTER TABLE foo ADD COLUMN bar integer", query.AlterTableAddColumn{TableName: "foo",
+			Constraint: database.FieldConstraint{
+				Path: parsePath(t, "bar"),
+				Type: document.IntegerValue,
+			},
+		}, false},
+		{"With not null", "ALTER TABLE foo ADD COLUMN bar NOT NULL", query.AlterTableAddColumn{TableName: "foo",
+			Constraint: database.FieldConstraint{
+				Path:      parsePath(t, "bar"),
+				IsNotNull: true,
+			},
+		}, false},
+		{"With primary key", "ALTER TABLE foo ADD COLUMN bar PRIMARY KEY", query.AlterTableAddColumn{TableName: "foo",
+			Constraint: database.FieldConstraint{
+				Path:         parsePath(t, "bar"),
+				IsPrimaryKey: true,
+			},
+		}, false},
+		{"With multiple constraints", "ALTER TABLE foo ADD COLUMN bar integer NOT NULL DEFAULT 0", query.AlterTableAddColumn{TableName: "foo",
+			Constraint: database.FieldConstraint{
+				Path:         parsePath(t, "bar"),
+				Type:         document.IntegerValue,
+				IsNotNull:    true,
+				DefaultValue: document.NewIntegerValue(0),
+			},
+		}, false},
 	}
 
 	for _, test := range tests {

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -76,10 +76,9 @@ func (p *Parser) parseIfNotExists() (bool, error) {
 	return true, nil
 }
 
-func (p *Parser) parseField(fc *database.FieldConstraint) (err error) {
+func (p *Parser) parseFieldDefinition(fc *database.FieldConstraint) (err error) {
 	fc.Path, err = p.parsePath()
 	if err != nil {
-		p.Unscan()
 		return err
 	}
 
@@ -104,7 +103,7 @@ func (p *Parser) parseFieldConstraints(info *database.TableInfo) error {
 	for {
 		var fc database.FieldConstraint
 
-		err = p.parseField(&fc)
+		err = p.parseFieldDefinition(&fc)
 		if err != nil {
 			return err
 		}

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -80,6 +80,7 @@ func (p *Parser) parseField(fc *database.FieldConstraint) (err error) {
 	fc.Path, err = p.parsePath()
 	if err != nil {
 		p.Unscan()
+		return err
 	}
 
 	fc.Type, err = p.parseType()

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -76,6 +76,20 @@ func (p *Parser) parseIfNotExists() (bool, error) {
 	return true, nil
 }
 
+func (p *Parser) parseField(fc *database.FieldConstraint) (err error) {
+	fc.Path, err = p.parsePath()
+	if err != nil {
+		p.Unscan()
+	}
+
+	fc.Type, err = p.parseType()
+	if err != nil {
+		return err
+	}
+
+	return p.parseFieldConstraint(fc)
+}
+
 func (p *Parser) parseFieldConstraints(info *database.TableInfo) error {
 	// Parse ( token.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LPAREN {
@@ -89,18 +103,7 @@ func (p *Parser) parseFieldConstraints(info *database.TableInfo) error {
 	for {
 		var fc database.FieldConstraint
 
-		fc.Path, err = p.parsePath()
-		if err != nil {
-			p.Unscan()
-			break
-		}
-
-		fc.Type, err = p.parseType()
-		if err != nil {
-			return err
-		}
-
-		err = p.parseFieldConstraint(&fc)
+		err = p.parseField(&fc)
 		if err != nil {
 			return err
 		}

--- a/sql/parser/create_test.go
+++ b/sql/parser/create_test.go
@@ -48,6 +48,17 @@ func TestParserCreateTable(t *testing.T) {
 					},
 				},
 			}, false},
+		{"With default", "CREATE TABLE test(foo DEFAULT \"10\")",
+			query.CreateTableStmt{
+				TableName: "test",
+				Info: database.TableInfo{
+					FieldConstraints: []database.FieldConstraint{
+						{Path: parsePath(t, "foo"), DefaultValue: document.NewTextValue("10")},
+					},
+				},
+			}, false},
+		{"With default twice", "CREATE TABLE test(foo DEFAULT 10 DEFAULT 10)",
+			query.CreateTableStmt{}, true},
 		{"With not null twice", "CREATE TABLE test(foo NOT NULL NOT NULL)",
 			query.CreateTableStmt{}, true},
 		{"With type and not null", "CREATE TABLE test(foo INTEGER NOT NULL)",

--- a/sql/query/alter.go
+++ b/sql/query/alter.go
@@ -40,19 +40,19 @@ func (stmt AlterStmt) Run(ctx context.Context, tx *database.Transaction, _ []exp
 	return res, err
 }
 
-type AlterTableAddColumn struct {
+type AlterTableAddField struct {
 	TableName  string
 	Constraint database.FieldConstraint
 }
 
 // IsReadOnly always returns false. It implements the Statement interface.
-func (stmt AlterTableAddColumn) IsReadOnly() bool {
+func (stmt AlterTableAddField) IsReadOnly() bool {
 	return false
 }
 
-// Run runs the ALTER TABLE ADD COLUMN statement in the given transaction.
+// Run runs the ALTER TABLE ADD COLUMN/FIELD statement in the given transaction.
 // It implements the Statement interface.
-func (stmt AlterTableAddColumn) Run(ctx context.Context, tx *database.Transaction, _ []expr.Param) (Result, error) {
+func (stmt AlterTableAddField) Run(ctx context.Context, tx *database.Transaction, _ []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {
@@ -63,6 +63,6 @@ func (stmt AlterTableAddColumn) Run(ctx context.Context, tx *database.Transactio
 		return res, errors.New("missing field name")
 	}
 
-	err := tx.AddColumn(stmt.TableName, stmt.Constraint)
+	err := tx.AddField(stmt.TableName, stmt.Constraint)
 	return res, err
 }

--- a/sql/query/alter.go
+++ b/sql/query/alter.go
@@ -50,7 +50,7 @@ func (stmt AlterTableAddField) IsReadOnly() bool {
 	return false
 }
 
-// Run runs the ALTER TABLE ADD COLUMN/FIELD statement in the given transaction.
+// Run runs the ALTER TABLE ADD FIELD statement in the given transaction.
 // It implements the Statement interface.
 func (stmt AlterTableAddField) Run(ctx context.Context, tx *database.Transaction, _ []expr.Param) (Result, error) {
 	var res Result

--- a/sql/query/alter.go
+++ b/sql/query/alter.go
@@ -39,3 +39,30 @@ func (stmt AlterStmt) Run(ctx context.Context, tx *database.Transaction, _ []exp
 	err := tx.RenameTable(stmt.TableName, stmt.NewTableName)
 	return res, err
 }
+
+type AlterTableAddColumn struct {
+	TableName  string
+	Constraint database.FieldConstraint
+}
+
+// IsReadOnly always returns false. It implements the Statement interface.
+func (stmt AlterTableAddColumn) IsReadOnly() bool {
+	return false
+}
+
+// Run runs the ALTER TABLE ADD COLUMN statement in the given transaction.
+// It implements the Statement interface.
+func (stmt AlterTableAddColumn) Run(ctx context.Context, tx *database.Transaction, _ []expr.Param) (Result, error) {
+	var res Result
+
+	if stmt.TableName == "" {
+		return res, errors.New("missing table name")
+	}
+
+	if stmt.Constraint.Path == nil {
+		return res, errors.New("missing field name")
+	}
+
+	err := tx.AddColumn(stmt.TableName, stmt.Constraint)
+	return res, err
+}

--- a/sql/scanner/scanner_test.go
+++ b/sql/scanner/scanner_test.go
@@ -125,6 +125,7 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `COMMIT`, tok: scanner.COMMIT, raw: `COMMIT`},
 		{s: `CREATE`, tok: scanner.CREATE, raw: `CREATE`},
 		{s: `EXPLAIN`, tok: scanner.EXPLAIN, raw: `EXPLAIN`},
+		{s: `DEFAULT`, tok: scanner.DEFAULT, raw: `DEFAULT`},
 		{s: `DELETE`, tok: scanner.DELETE, raw: `DELETE`},
 		{s: `DESC`, tok: scanner.DESC, raw: `DESC`},
 		{s: `DROP`, tok: scanner.DROP, raw: `DROP`},

--- a/sql/scanner/scanner_test.go
+++ b/sql/scanner/scanner_test.go
@@ -116,12 +116,14 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `-10.3`, tok: scanner.NUMBER, lit: `-10.3`, raw: `-10.3`},
 
 		// Keywords
+		{s: `ADD`, tok: scanner.ADD_KEYWORD, raw: `ADD`},
 		{s: `ALTER`, tok: scanner.ALTER, raw: `ALTER`},
 		{s: `AS`, tok: scanner.AS, raw: `AS`},
 		{s: `ASC`, tok: scanner.ASC, raw: `ASC`},
 		{s: `BY`, tok: scanner.BY, raw: `BY`},
 		{s: `BEGIN`, tok: scanner.BEGIN, raw: `BEGIN`},
 		{s: `CAST`, tok: scanner.CAST, raw: `CAST`},
+		{s: `COLUMN`, tok: scanner.COLUMN, raw: `COLUMN`},
 		{s: `COMMIT`, tok: scanner.COMMIT, raw: `COMMIT`},
 		{s: `CREATE`, tok: scanner.CREATE, raw: `CREATE`},
 		{s: `EXPLAIN`, tok: scanner.EXPLAIN, raw: `EXPLAIN`},

--- a/sql/scanner/scanner_test.go
+++ b/sql/scanner/scanner_test.go
@@ -131,6 +131,7 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `DELETE`, tok: scanner.DELETE, raw: `DELETE`},
 		{s: `DESC`, tok: scanner.DESC, raw: `DESC`},
 		{s: `DROP`, tok: scanner.DROP, raw: `DROP`},
+		{s: `FIELD`, tok: scanner.FIELD, raw: `FIELD`},
 		{s: `FROM`, tok: scanner.FROM, raw: `FROM`},
 		{s: `GROUP`, tok: scanner.GROUP, raw: `GROUP`},
 		{s: `INSERT`, tok: scanner.INSERT, raw: `INSERT`},

--- a/sql/scanner/scanner_test.go
+++ b/sql/scanner/scanner_test.go
@@ -123,7 +123,6 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `BY`, tok: scanner.BY, raw: `BY`},
 		{s: `BEGIN`, tok: scanner.BEGIN, raw: `BEGIN`},
 		{s: `CAST`, tok: scanner.CAST, raw: `CAST`},
-		{s: `COLUMN`, tok: scanner.COLUMN, raw: `COLUMN`},
 		{s: `COMMIT`, tok: scanner.COMMIT, raw: `COMMIT`},
 		{s: `CREATE`, tok: scanner.CREATE, raw: `CREATE`},
 		{s: `EXPLAIN`, tok: scanner.EXPLAIN, raw: `EXPLAIN`},

--- a/sql/scanner/token.go
+++ b/sql/scanner/token.go
@@ -79,7 +79,6 @@ const (
 	BEGIN
 	BY
 	CAST
-	COLUMN
 	COMMIT
 	CREATE
 	DEFAULT
@@ -200,7 +199,6 @@ var tokens = [...]string{
 	ASC:         "ASC",
 	BEGIN:       "BEGIN",
 	COMMIT:      "COMMIT",
-	COLUMN:      "COLUMN",
 	GROUP:       "GROUP",
 	BY:          "BY",
 	CREATE:      "CREATE",

--- a/sql/scanner/token.go
+++ b/sql/scanner/token.go
@@ -88,6 +88,7 @@ const (
 	DROP
 	EXISTS
 	EXPLAIN
+	FIELD
 	FROM
 	GROUP
 	IF
@@ -211,6 +212,7 @@ var tokens = [...]string{
 	EXISTS:      "EXISTS",
 	EXPLAIN:     "EXPLAIN",
 	KEY:         "KEY",
+	FIELD:       "FIELD",
 	FROM:        "FROM",
 	IF:          "IF",
 	INDEX:       "INDEX",

--- a/sql/scanner/token.go
+++ b/sql/scanner/token.go
@@ -80,6 +80,7 @@ const (
 	CAST
 	COMMIT
 	CREATE
+	DEFAULT
 	DELETE
 	DESC
 	DROP
@@ -199,6 +200,7 @@ var tokens = [...]string{
 	BY:          "BY",
 	CREATE:      "CREATE",
 	CAST:        "CAST",
+	DEFAULT:     "DEFAULT",
 	DELETE:      "DELETE",
 	DESC:        "DESC",
 	DROP:        "DROP",

--- a/sql/scanner/token.go
+++ b/sql/scanner/token.go
@@ -72,12 +72,14 @@ const (
 
 	keywordBeg
 	// ALL and the following are Genji SQL Keywords
+	ADD_KEYWORD
 	ALTER
 	AS
 	ASC
 	BEGIN
 	BY
 	CAST
+	COLUMN
 	COMMIT
 	CREATE
 	DEFAULT
@@ -191,11 +193,13 @@ var tokens = [...]string{
 	SEMICOLON:   ";",
 	DOT:         ".",
 
+	ADD_KEYWORD: "ADD",
 	ALTER:       "ALTER",
 	AS:          "AS",
 	ASC:         "ASC",
 	BEGIN:       "BEGIN",
 	COMMIT:      "COMMIT",
+	COLUMN:      "COLUMN",
 	GROUP:       "GROUP",
 	BY:          "BY",
 	CREATE:      "CREATE",


### PR DESCRIPTION
Fixes #96.

Adds:
- New `DEFAULT` constraint which sets default value of field/column.
- `ALTER TABLE <table_name> ADD COLUMN <field definition>` statement to add new fields to the table. Original issue requests `ADD FIELD` statement, but I think `ADD COLUMN` is more compatible with SQL. Anyway, it's not too hard to fix.

I have some questions about the _correct_ table info modification. 