### PR TITLE
Revert "Display doubles with a decimal point"

### DIFF
--- a/document/value.go
+++ b/document/value.go
@@ -250,10 +250,15 @@ func (v Value) MarshalJSON() ([]byte, error) {
 		return strconv.AppendInt(nil, v.V.(int64), 10), nil
 	case DoubleValue:
 		f := v.V.(float64)
-		if f == float64(int(f)) {
-			return strconv.AppendFloat(nil, f, 'f', 1, 64), nil
+		abs := math.Abs(f)
+		fmt := byte('f')
+		if abs != 0 {
+			if abs < 1e-6 || abs >= 1e21 {
+				fmt = 'e'
+			}
 		}
-		return strconv.AppendFloat(nil, f, 'f', -1, 64), nil
+
+		return strconv.AppendFloat(nil, v.V.(float64), fmt, -1, 64), nil
 	case TextValue:
 		return []byte(strconv.Quote(v.V.(string))), nil
 	case BlobValue:

--- a/document/value_test.go
+++ b/document/value_test.go
@@ -21,7 +21,6 @@ func TestValueString(t *testing.T) {
 		{"bool", document.NewBoolValue(true), "true"},
 		{"int", document.NewIntegerValue(10), "10"},
 		{"double", document.NewDoubleValue(10.1), "10.1"},
-		{"double", document.NewDoubleValue(10), "10.0"},
 		{"document", document.NewDocumentValue(document.NewFieldBuffer().Add("a", document.NewIntegerValue(10))), "{\"a\": 10}"},
 		{"array", document.NewArrayValue(document.NewValueBuffer(document.NewIntegerValue(10))), "[10]"},
 	}


### PR DESCRIPTION
Reverts genjidb/genji#246 since the change doesn’t fix the issue for all possible values and introduces regressions.

- For some reason exponent formatting (see [encoding/json implementation](https://github.com/golang/go/blob/d4a5797b8863185230d0e89da9a00fd17f04152a/src/encoding/json/encode.go#L577-L603)) was removed.

- Checking `f == float64(int(f))` fails if f is greater than the maximum int value.

  A better way would be to check [`_, frac := math.Modf(f); frac == 0`](https://golang.org/pkg/math#Modf) or [`math.Mod(f, 1) == 0`](https://golang.org/pkg/math#Mod).

  ```
  f := 1e42
  fmt.Println(f == float64(int(f)))
  _, frac := math.Modf(f); fmt.Println(frac == 0)
  fmt.Println(math.Mod(f, 1))
  ```

  Alternatively, we can just insert `.0` if it’s note already there.

FWIW it’d also be nice to return an error on `math.IsInf(f, 0) || math.IsNaN(f)` just like the Go standard library does.

@Amirhossein2000 would you like to tackle this issue again taking the suggestions in mind?
