### PR TITLE
Do not panic on genji version when compiled in GOPATH mode

### DIFF
--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -93,10 +93,13 @@ $ curl https://api.github.com/repos/genjidb/genji/issues | genji insert --db my.
 			Action: func(c *cli.Context) error {
 				var cliVersion, genjiVersion string
 				info, ok := debug.ReadBuildInfo()
-				if ok {
-					cliVersion = info.Main.Version
+
+				if !ok {
+					fmt.Println("version not available in GOPATH mode")
+					return nil
 				}
 
+				cliVersion = info.Main.Version
 				for _, mod := range info.Deps {
 					if mod.Path != "github.com/genjidb/genji" {
 						continue

--- a/cmd/genji/main.go
+++ b/cmd/genji/main.go
@@ -95,7 +95,7 @@ $ curl https://api.github.com/repos/genjidb/genji/issues | genji insert --db my.
 				info, ok := debug.ReadBuildInfo()
 
 				if !ok {
-					fmt.Println("version not available in GOPATH mode")
+					fmt.Println(`version not available in GOPATH mode; use "go get" with Go modules enabled`)
 					return nil
 				}
 


### PR DESCRIPTION
The `genji version` command relies on the versions of modules compiled in as debug info. Those are unavailable when compiling Genji with `go get github.com/genjidb/genji/cmd/shell` (in GOPATH mode). This makes `genji version` display a message saying the version is not available if genji has been built with `go get`.

Sample output:

```
genji on master [!?] via v1.15.2 > GO111MODULE=off go run github.com/genjidb/genji/cmd/genji version
Using z.Allocator with starting ref: 8005000000000000
version not available in GOPATH mode
```