### PR TITLE
Wrap error from strconv.Atoi inside ParseError

### DIFF
--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -432,7 +432,7 @@ LOOP:
 			}
 			idx, err := strconv.Atoi(lit)
 			if err != nil {
-				return nil, err
+				return nil, newParseError(lit, []string{"integer"}, pos)
 			}
 			vPath = append(vPath, document.ValuePathFragment{
 				ArrayIndex: idx,


### PR DESCRIPTION
This wraps the error returned by `strconv.Atoi` inside `ParseError`

Fixes #256 