### PR TITLE
Ignore currently unsupported regex operators

### DIFF
--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -84,6 +84,12 @@ func (p *Parser) parseOperator() (func(lhs, rhs expr.Expr) expr.Expr, scanner.To
 		return nil, 0, nil
 	}
 
+	// Ignore currently unused operators.
+	if op == scanner.EQREGEX || op == scanner.NEQREGEX {
+		p.Unscan()
+		return nil, 0, nil
+	}
+
 	switch op {
 	case scanner.EQ:
 		return expr.Eq, op, nil


### PR DESCRIPTION
This PR ignores currently unsupported operators in `parseOperator`.

```
genji> SELECT 0 !~ 1;
found !~, expected ; at line 1, char 10
genji> SELECT 0 1;
found 1, expected ; at line 1, char 10
```

Closes #252