### PR TITLE
Fix fuzz workflow failing when there are no crashers

### DIFF
--- a/.github/workflows/test-fuzz.yaml
+++ b/.github/workflows/test-fuzz.yaml
@@ -85,7 +85,10 @@ jobs:
       - name: Run tests
         run: |
           go run github.com/dvyukov/go-fuzz/go-fuzz-build -func ${{ matrix.func }} && timeout -s INT -k 30 300 \
-          go run github.com/dvyukov/go-fuzz/go-fuzz -workdir=testdata/fuzz/${{ matrix.func }} -dumpcover
+          go run github.com/dvyukov/go-fuzz/go-fuzz -workdir=testdata/fuzz/${{ matrix.func }} -dumpcover || true
+          if [ -d crashers ]; then
+            exit 1
+          fi
         working-directory: genji/fuzz
 
       - name: Prepare report


### PR DESCRIPTION
Interrupting go-fuzz always returns non-zero error code, so we should ignore it. Check whether `crashers` directory exists instead.
