### PR TITLE
Fix badgerengine tests on Windows

### DIFF
--- a/engine/badgerengine/engine_test.go
+++ b/engine/badgerengine/engine_test.go
@@ -3,7 +3,7 @@ package badgerengine_test
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -16,7 +16,7 @@ import (
 func builder(t testing.TB) func() (engine.Engine, func()) {
 	return func() (engine.Engine, func()) {
 		dir, cleanup := tempDir(t)
-		opts := badger.DefaultOptions(path.Join(dir, "badger"))
+		opts := badger.DefaultOptions(filepath.Join(dir, "badger"))
 		opts.Logger = nil
 
 		ng, err := badgerengine.NewEngine(opts)

--- a/engine/badgerengine/example_test.go
+++ b/engine/badgerengine/example_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/genjidb/genji"
@@ -18,7 +18,7 @@ func Example() {
 	}
 	defer os.RemoveAll(dir)
 
-	ng, err := badgerengine.NewEngine(badger.DefaultOptions(path.Join(dir, "badger")))
+	ng, err := badgerengine.NewEngine(badger.DefaultOptions(filepath.Join(dir, "badger")))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/boltengine/engine_test.go
+++ b/engine/boltengine/engine_test.go
@@ -3,7 +3,7 @@ package boltengine_test
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/genjidb/genji/engine"
@@ -15,7 +15,7 @@ import (
 func builder(t testing.TB) func() (engine.Engine, func()) {
 	return func() (engine.Engine, func()) {
 		dir, cleanup := tempDir(t)
-		ng, err := boltengine.NewEngine(path.Join(dir, "test.db"), 0600, nil)
+		ng, err := boltengine.NewEngine(filepath.Join(dir, "test.db"), 0o600, nil)
 		require.NoError(t, err)
 		return ng, cleanup
 	}

--- a/engine/boltengine/example_test.go
+++ b/engine/boltengine/example_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/genjidb/genji"
 	"github.com/genjidb/genji/engine/boltengine"
@@ -17,7 +17,7 @@ func Example() {
 	}
 	defer os.RemoveAll(dir)
 
-	db, err := genji.Open(path.Join(dir, "my.db"))
+	db, err := genji.Open(filepath.Join(dir, "my.db"))
 	defer db.Close()
 	if err != nil {
 		log.Fatal(err)
@@ -31,7 +31,7 @@ func ExampleNewEngine() {
 	}
 	defer os.RemoveAll(dir)
 
-	ng, err := boltengine.NewEngine(path.Join(dir, "genji.db"), 0600, nil)
+	ng, err := boltengine.NewEngine(filepath.Join(dir, "genji.db"), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/enginetest/benchmark.go
+++ b/engine/enginetest/benchmark.go
@@ -17,13 +17,14 @@ func BenchmarkStorePut(b *testing.B, builder Builder) {
 		b.Run(fmt.Sprintf("%.05d", size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				st, cleanup := storeBuilder(b, builder)
+				defer cleanup()
 
+				b.ResetTimer()
 				for j := 0; j < size; j++ {
 					k := []byte(fmt.Sprintf("k%d", j))
-
 					st.Put(k, v)
 				}
-				cleanup()
+				b.StopTimer()
 			}
 		})
 	}


### PR DESCRIPTION
This PR ensures that we close engine before cleanup in `enginetest`. On Windows tests were failing with the following error.
<details>

```
2020/10/23 21:27:17 remove C:\Users\RUNNER~1\AppData\Local\Temp\genji245175255/badger\000000.vlog: The process cannot access the file because it is being used by another process.
  
  github.com/dgraph-io/badger/v2/y.Wrap
  	github.com/dgraph-io/badger/v2@v2.2007.2/y/error.go:71
  github.com/dgraph-io/badger/v2/y.Check
  	github.com/dgraph-io/badger/v2@v2.2007.2/y/error.go:43
  github.com/dgraph-io/badger/v2.(*valueLog).createVlogFile.func1
  	github.com/dgraph-io/badger/v2@v2.2007.2/value.go:1008
  github.com/dgraph-io/badger/v2.(*valueLog).createVlogFile
  	github.com/dgraph-io/badger/v2@v2.2007.2/value.go:1022
  github.com/dgraph-io/badger/v2.(*valueLog).open
  	github.com/dgraph-io/badger/v2@v2.2007.2/value.go:1120
  github.com/dgraph-io/badger/v2.Open
  	github.com/dgraph-io/badger/v2@v2.2007.2/db.go:396
  github.com/genjidb/genji/engine/badgerengine.NewEngine
  	github.com/genjidb/genji/engine/badgerengine/engine.go:24
  github.com/genjidb/genji/engine/badgerengine_test.builder.func1
  	github.com/genjidb/genji/engine/badgerengine_test/engine_test.go:22
  github.com/genjidb/genji/engine/enginetest.TestStoreNextSequence.func3
  	github.com/genjidb/genji@v0.9.0/engine/enginetest/testing.go:824
  testing.tRunner
  	testing/testing.go:1054
  runtime.goexit
  	runtime/asm_amd64.s:1373
```
</details>
