### PR TITLE
Add support for context.Context APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ There are two ways of using Genji, either by using Genji's API or by using the [
 package main
 
 import (
-	"fmt"
-	"log"
+    "context"
+    "fmt"
+    "log"
 
-	"github.com/genjidb/genji"
-	"github.com/genjidb/genji/document"
+    "github.com/genjidb/genji"
+    "github.com/genjidb/genji/document"
 )
 
 func main() {
@@ -82,19 +83,20 @@ func main() {
     // Don't forget to close the database when you're done
     defer db.Close()
 
-    ctx := context.Background()
+    // Attach context, e.g. (*http.Request).Context().
+    db = db.WithContext(context.Background())
 
     // Create a table. Schemas are optional, you don't need to specify one if not needed
-    err = db.Exec(ctx, "CREATE TABLE user")
+    err = db.Exec("CREATE TABLE user")
 
     // Create an index
-    err = db.Exec(ctx, "CREATE INDEX idx_user_name ON test (name)")
+    err = db.Exec("CREATE INDEX idx_user_name ON test (name)")
 
     // Insert some data
-    err = db.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "Foo1", 15)
+    err = db.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "Foo1", 15)
 
     // Supported values can go from simple integers to richer data types like lists or documents
-    err = db.Exec(ctx, `
+    err = db.Exec(`
     INSERT INTO user (id, name, age, address, friends)
     VALUES (
         11,
@@ -124,10 +126,10 @@ func main() {
     u.Address.City = "Lyon"
     u.Address.ZipCode = "69001"
 
-    err = db.Exec(ctx, `INSERT INTO user VALUES ?`, &u)
+    err = db.Exec(`INSERT INTO user VALUES ?`, &u)
 
     // Query some documents
-    res, err := db.Query(ctx, "SELECT id, name, age, address FROM user WHERE age >= ?", 18)
+    res, err := db.Query("SELECT id, name, age, address FROM user WHERE age >= ?", 18)
     // always close the result when you're done with it
     defer res.Close()
 
@@ -240,6 +242,7 @@ go get github.com/genjidb/genji/engine/badgerengine
 
 ```go
 import (
+    "context"
     "log"
 
     "github.com/genjidb/genji"
@@ -255,7 +258,7 @@ func main() {
     }
 
     // Pass it to genji
-    db, err := genji.New(ng)
+    db, err := genji.New(context.Background(), ng)
     if err != nil {
         log.Fatal(err)
     }

--- a/cmd/genji/insert.go
+++ b/cmd/genji/insert.go
@@ -38,7 +38,7 @@ func skipSpaces(r *bufio.Reader) (byte, error) {
 	return c, nil
 }
 
-func executeInsertCommand(ctx context.Context, db *genji.DB, table string, r io.Reader) error {
+func executeInsertCommand(db *genji.DB, table string, r io.Reader) error {
 	q := fmt.Sprintf("INSERT INTO %s VALUES ?", table)
 	rd := bufio.NewReader(r)
 	var c byte
@@ -66,7 +66,7 @@ func executeInsertCommand(ctx context.Context, db *genji.DB, table string, r io.
 				return err
 			}
 
-			if err := db.Exec(ctx, q, &fb); err != nil {
+			if err := db.Exec(q, &fb); err != nil {
 				return err
 			}
 		}
@@ -89,7 +89,7 @@ func executeInsertCommand(ctx context.Context, db *genji.DB, table string, r io.
 				return err
 			}
 
-			if err := db.Exec(ctx, q, &fb); err != nil {
+			if err := db.Exec(q, &fb); err != nil {
 				return err
 			}
 		}
@@ -137,14 +137,14 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 		return err
 	}
 
-	db, err := genji.New(ng)
+	db, err := genji.New(ctx, ng)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
 	if createTable {
-		err := db.Exec(ctx, "CREATE TABLE "+table)
+		err := db.Exec("CREATE TABLE " + table)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 	fi, _ := os.Stdin.Stat()
 	m := fi.Mode()
 	if (m & os.ModeNamedPipe) != 0 {
-		return executeInsertCommand(ctx, db, table, os.Stdin)
+		return executeInsertCommand(db, table, os.Stdin)
 	}
 
 	if len(args) == 0 {
@@ -161,7 +161,7 @@ func runInsertCommand(ctx context.Context, e, dbPath, table string, auto bool, a
 	}
 
 	for _, arg := range args {
-		if err := executeInsertCommand(ctx, db, table, strings.NewReader(arg)); err != nil {
+		if err := executeInsertCommand(db, table, strings.NewReader(arg)); err != nil {
 			return err
 		}
 	}

--- a/cmd/genji/insert_test.go
+++ b/cmd/genji/insert_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -12,8 +11,6 @@ import (
 )
 
 func TestExecuteInsertCommand(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name  string
 		data  string
@@ -35,16 +32,16 @@ func TestExecuteInsertCommand(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, `CREATE TABLE foo`)
+			err = db.Exec(`CREATE TABLE foo`)
 			require.NoError(t, err)
-			err = executeInsertCommand(context.Background(), db, "foo", strings.NewReader(tt.data))
+			err = executeInsertCommand(db, "foo", strings.NewReader(tt.data))
 			if tt.fails {
 				require.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			res, err := db.Query(ctx, "SELECT * FROM foo")
+			res, err := db.Query("SELECT * FROM foo")
 			defer res.Close()
 			require.NoError(t, err)
 
@@ -75,11 +72,11 @@ func TestExecuteInsertCommand(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, `CREATE TABLE foo`)
+		err = db.Exec(`CREATE TABLE foo`)
 		require.NoError(t, err)
-		err = executeInsertCommand(context.Background(), db, "foo", strings.NewReader(jsonArray))
+		err = executeInsertCommand(db, "foo", strings.NewReader(jsonArray))
 		require.NoError(t, err)
-		res, err := db.Query(ctx, "SELECT * FROM foo")
+		res, err := db.Query("SELECT * FROM foo")
 		defer res.Close()
 		require.NoError(t, err)
 
@@ -110,13 +107,13 @@ func TestExecuteInsertCommand(t *testing.T) {
 		defer db.Close()
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `CREATE TABLE foo`)
+		err = db.Exec(`CREATE TABLE foo`)
 		require.NoError(t, err)
 
-		err = executeInsertCommand(context.Background(), db, "foo", strings.NewReader(jsonStream))
+		err = executeInsertCommand(db, "foo", strings.NewReader(jsonStream))
 		require.NoError(t, err)
 
-		res, err := db.Query(ctx, "SELECT * FROM foo")
+		res, err := db.Query("SELECT * FROM foo")
 		defer res.Close()
 		require.NoError(t, err)
 

--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -58,9 +57,7 @@ func runTablesCmd(db *genji.DB, cmd []string) error {
 		return fmt.Errorf("usage: .tables")
 	}
 
-	ctx := context.Background()
-
-	res, err := db.Query(ctx, "SELECT table_name FROM __genji_tables")
+	res, err := db.Query("SELECT table_name FROM __genji_tables")
 	if err != nil {
 		return err
 	}
@@ -80,17 +77,15 @@ func runTablesCmd(db *genji.DB, cmd []string) error {
 // displayTableIndex prints all indexes that the given table contains.
 func displayTableIndex(db *genji.DB, tableName string) error {
 	return db.View(func(tx *genji.Tx) error {
-		ctx := context.Background()
-		_, err := tx.QueryDocument(ctx, "SELECT table_name FROM __genji_tables WHERE table_name = ?", tableName)
+		_, err := tx.QueryDocument("SELECT table_name FROM __genji_tables WHERE table_name = ?", tableName)
 		if err != nil {
 			if err == database.ErrDocumentNotFound {
 				return fmt.Errorf("%w: %q", database.ErrTableNotFound, tableName)
 			}
-
 			return err
 		}
 
-		res, err := tx.Query(ctx, "SELECT * FROM __genji_indexes WHERE table_name = ?", tableName)
+		res, err := tx.Query("SELECT * FROM __genji_indexes WHERE table_name = ?", tableName)
 		if err != nil {
 			return err
 		}
@@ -112,9 +107,7 @@ func displayTableIndex(db *genji.DB, tableName string) error {
 
 // displayAllIndexes shows all indexes that the database contains.
 func displayAllIndexes(db *genji.DB) error {
-	ctx := context.Background()
-
-	res, err := db.Query(ctx, "SELECT * FROM __genji_indexes")
+	res, err := db.Query("SELECT * FROM __genji_indexes")
 	if err != nil {
 		return err
 	}
@@ -272,7 +265,7 @@ func dumpTable(tx *genji.Tx, tableName string, w io.Writer) error {
 	}
 
 	q := fmt.Sprintf("SELECT * FROM %s", t.Name())
-	res, err := tx.Query(context.Background(), q)
+	res, err := tx.Query(q)
 	if err != nil {
 		return err
 	}
@@ -340,7 +333,7 @@ func runDumpCmd(db *genji.DB, tables []string, w io.Writer) error {
 
 	// tables slice argument is empty.
 	// Dump database content.
-	res, err := tx.Query(context.Background(), "SELECT table_name FROM __genji_tables")
+	res, err := tx.Query("SELECT table_name FROM __genji_tables")
 	if err != nil {
 		_, err = fmt.Fprintln(w, "ROLLBACK;")
 		return err

--- a/cmd/genji/shell/command_test.go
+++ b/cmd/genji/shell/command_test.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -70,11 +69,9 @@ func TestIndexesCmd(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			ctx := context.Background()
-
-			err = db.Exec(ctx, "CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 						CREATE INDEX idx_a ON test (a);
 						CREATE INDEX idx_b ON test (b);
 						CREATE INDEX idx_c ON test (c);
@@ -101,8 +98,6 @@ func TestRunDumpCmd(t *testing.T) {
 		{"text / pk and not null with type constraint", `INSERT INTO test (a, b, c) VALUES ('a', 'b', 'c')`, `TEXT PRIMARY KEY NOT NULL`, `INSERT INTO test VALUES {"a": "a", "b": "b", "c": "c"};`, false, nil},
 	}
 
-	ctx := context.Background()
-
 	for _, tt := range tests {
 
 		testFn := func(withIndexes, withConstraints bool) func(t *testing.T) {
@@ -118,19 +113,19 @@ func TestRunDumpCmd(t *testing.T) {
 				ci := "COMMIT;\n"
 				if withConstraints {
 					q := fmt.Sprintf("CREATE TABLE test (\n  a %s\n);\n", tt.fieldConstraint)
-					err := db.Exec(ctx, q)
+					err := db.Exec(q)
 					require.NoError(t, err)
 					bwant.WriteString(q)
 				} else {
 					q := `CREATE TABLE test;`
-					err = db.Exec(ctx, q)
+					err = db.Exec(q)
 					require.NoError(t, err)
 					q = fmt.Sprintf("%s\n", q)
 					bwant.WriteString(q)
 				}
 
 				if withIndexes {
-					err = db.Exec(ctx, `
+					err = db.Exec(`
 						CREATE INDEX idx_a ON test (a);
 					`)
 					require.NoError(t, err)
@@ -149,7 +144,7 @@ func TestRunDumpCmd(t *testing.T) {
 					require.NoError(t, err)
 
 				}
-				err = db.Exec(context.Background(), tt.query, tt.params...)
+				err = db.Exec(tt.query, tt.params...)
 				if tt.fails {
 					require.Error(t, err)
 					return

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -630,7 +630,7 @@ func (sh *Shell) getAllTables(ctx context.Context) ([]string, error) {
 func (sh *Shell) completer(in prompt.Document) []prompt.Suggest {
 	suggestions := prompt.FilterHasPrefix(sh.cmdSuggestions, in.Text, true)
 
-	_, err := parser.NewParser(strings.NewReader(in.Text)).ParseQuery(context.Background())
+	_, err := parser.ParseQuery(in.Text)
 	if err != nil {
 		e, ok := err.(*parser.ParseError)
 		if !ok || len(e.Expected) < 1 {

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -1,11 +1,13 @@
 package database
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/document/encoding/msgpack"
+	"github.com/genjidb/genji/engine"
 	"github.com/genjidb/genji/engine/memoryengine"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +39,9 @@ func TestTableInfoStore(t *testing.T) {
 		ng := memoryengine.NewEngine()
 		defer ng.Close()
 
-		db, err := New(ng, Options{Codec: msgpack.NewCodec()})
+		db, err := New(context.Background(), ng, Options{
+			Codec: msgpack.NewCodec(),
+		})
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -84,7 +88,9 @@ func TestTableInfoStore(t *testing.T) {
 		ng := memoryengine.NewEngine()
 		defer ng.Close()
 
-		db, err := New(ng, Options{Codec: msgpack.NewCodec()})
+		db, err := New(context.Background(), ng, Options{
+			Codec: msgpack.NewCodec(),
+		})
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -111,7 +117,9 @@ func TestTableInfoStore(t *testing.T) {
 		ng := memoryengine.NewEngine()
 		defer ng.Close()
 
-		db, err := New(ng, Options{Codec: msgpack.NewCodec()})
+		db, err := New(context.Background(), ng, Options{
+			Codec: msgpack.NewCodec(),
+		})
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -142,7 +150,9 @@ func TestIndexStore(t *testing.T) {
 	ng := memoryengine.NewEngine()
 	defer ng.Close()
 
-	tx, err := ng.Begin(true)
+	tx, err := ng.Begin(context.Background(), engine.TxOptions{
+		Writable: true,
+	})
 	require.NoError(t, err)
 	defer tx.Rollback()
 

--- a/database/table.go
+++ b/database/table.go
@@ -330,7 +330,7 @@ func (t *Table) Iterate(fn func(d document.Document) error) error {
 		codec: t.tx.db.Codec,
 	}
 
-	it := t.Store.NewIterator(engine.IteratorConfig{})
+	it := t.Store.Iterator(engine.IteratorOptions{})
 	defer it.Close()
 
 	var err error
@@ -344,6 +344,9 @@ func (t *Table) Iterate(fn func(d document.Document) error) error {
 		if err != nil {
 			return err
 		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/database/table_test.go
+++ b/database/table_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -152,7 +153,9 @@ func TestTableInsert(t *testing.T) {
 	t.Run("Should generate the right docid on existing databases", func(t *testing.T) {
 		ng := memoryengine.NewEngine()
 
-		db, err := database.New(ng, database.Options{Codec: msgpack.NewCodec()})
+		db, err := database.New(context.Background(), ng, database.Options{
+			Codec: msgpack.NewCodec(),
+		})
 		require.NoError(t, err)
 
 		insertDoc := func(db *database.Database) []byte {
@@ -179,7 +182,9 @@ func TestTableInsert(t *testing.T) {
 		require.NoError(t, err)
 
 		// create new database object
-		db, err = database.New(ng, database.Options{Codec: msgpack.NewCodec()})
+		db, err = database.New(context.Background(), ng, database.Options{
+			Codec: msgpack.NewCodec(),
+		})
 		require.NoError(t, err)
 
 		key2 := insertDoc(db)

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -1,8 +1,10 @@
 package database_test
 
 import (
+	"context"
 	"errors"
 	"testing"
+
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/document/encoding/msgpack"
@@ -12,7 +14,9 @@ import (
 )
 
 func newTestDB(t testing.TB) (*database.Transaction, func()) {
-	db, err := database.New(memoryengine.NewEngine(), database.Options{Codec: msgpack.NewCodec()})
+	db, err := database.New(context.Background(), memoryengine.NewEngine(), database.Options{
+		Codec: msgpack.NewCodec(),
+	})
 	require.NoError(t, err)
 
 	tx, err := db.Begin(true)
@@ -47,7 +51,9 @@ func TestTxTable(t *testing.T) {
 	})
 
 	t.Run("Create and rollback", func(t *testing.T) {
-		db, err := database.New(memoryengine.NewEngine(), database.Options{Codec: msgpack.NewCodec()})
+		db, err := database.New(context.Background(), memoryengine.NewEngine(), database.Options{
+			Codec: msgpack.NewCodec(),
+		})
 		require.NoError(t, err)
 		defer db.Close()
 

--- a/db.go
+++ b/db.go
@@ -40,7 +40,6 @@ func (db *DB) Begin(writable bool) (*Tx, error) {
 
 	return &Tx{
 		Transaction: tx,
-		Context:     db.Context,
 	}, nil
 }
 
@@ -84,7 +83,7 @@ func (db *DB) Exec(q string, args ...interface{}) error {
 // Query the database and return the result.
 // The returned result must always be closed after usage.
 func (db *DB) Query(q string, args ...interface{}) (*query.Result, error) {
-	pq, err := parser.ParseQuery(db.Context, q)
+	pq, err := parser.ParseQuery(q)
 	if err != nil {
 		return nil, err
 	}
@@ -125,21 +124,12 @@ func (db *DB) QueryDocument(q string, args ...interface{}) (document.Document, e
 // and read/write can be used to read, create, delete and modify tables.
 type Tx struct {
 	*database.Transaction
-
-	Context context.Context
-}
-
-func (tx *Tx) WithContext(ctx context.Context) *Tx {
-	return &Tx{
-		Transaction: tx.Transaction,
-		Context:     ctx,
-	}
 }
 
 // Query the database withing the transaction and returns the result.
 // Closing the returned result after usage is not mandatory.
 func (tx *Tx) Query(q string, args ...interface{}) (*query.Result, error) {
-	pq, err := parser.ParseQuery(tx.Context, q)
+	pq, err := parser.ParseQuery(q)
 	if err != nil {
 		return nil, err
 	}

--- a/db.go
+++ b/db.go
@@ -12,6 +12,15 @@ import (
 // DB represents a collection of tables stored in the underlying engine.
 type DB struct {
 	DB *database.Database
+
+	Context context.Context
+}
+
+func (db *DB) WithContext(ctx context.Context) *DB {
+	return &DB{
+		DB:      db.DB,
+		Context: ctx,
+	}
 }
 
 // Close the database.
@@ -22,13 +31,16 @@ func (db *DB) Close() error {
 // Begin starts a new transaction.
 // The returned transaction must be closed either by calling Rollback or Commit.
 func (db *DB) Begin(writable bool) (*Tx, error) {
-	tx, err := db.DB.Begin(writable)
+	tx, err := db.DB.BeginTx(db.Context, &database.TxOptions{
+		ReadOnly: !writable,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &Tx{
 		Transaction: tx,
+		Context:     db.Context,
 	}, nil
 }
 
@@ -60,8 +72,8 @@ func (db *DB) Update(fn func(tx *Tx) error) error {
 }
 
 // Exec a query against the database without returning the result.
-func (db *DB) Exec(ctx context.Context, q string, args ...interface{}) error {
-	res, err := db.Query(ctx, q, args...)
+func (db *DB) Exec(q string, args ...interface{}) error {
+	res, err := db.Query(q, args...)
 	if err != nil {
 		return err
 	}
@@ -71,19 +83,19 @@ func (db *DB) Exec(ctx context.Context, q string, args ...interface{}) error {
 
 // Query the database and return the result.
 // The returned result must always be closed after usage.
-func (db *DB) Query(ctx context.Context, q string, args ...interface{}) (*query.Result, error) {
-	pq, err := parser.ParseQuery(ctx, q)
+func (db *DB) Query(q string, args ...interface{}) (*query.Result, error) {
+	pq, err := parser.ParseQuery(db.Context, q)
 	if err != nil {
 		return nil, err
 	}
 
-	return pq.Run(ctx, db.DB, argsToParams(args))
+	return pq.Run(db.Context, db.DB, argsToParams(args))
 }
 
 // QueryDocument runs the query and returns the first document.
 // If the query returns no error, QueryDocument returns database.ErrDocumentNotFound.
-func (db *DB) QueryDocument(ctx context.Context, q string, args ...interface{}) (document.Document, error) {
-	res, err := db.Query(ctx, q, args...)
+func (db *DB) QueryDocument(q string, args ...interface{}) (document.Document, error) {
+	res, err := db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -113,23 +125,32 @@ func (db *DB) QueryDocument(ctx context.Context, q string, args ...interface{}) 
 // and read/write can be used to read, create, delete and modify tables.
 type Tx struct {
 	*database.Transaction
+
+	Context context.Context
+}
+
+func (tx *Tx) WithContext(ctx context.Context) *Tx {
+	return &Tx{
+		Transaction: tx.Transaction,
+		Context:     ctx,
+	}
 }
 
 // Query the database withing the transaction and returns the result.
 // Closing the returned result after usage is not mandatory.
-func (tx *Tx) Query(ctx context.Context, q string, args ...interface{}) (*query.Result, error) {
-	pq, err := parser.ParseQuery(ctx, q)
+func (tx *Tx) Query(q string, args ...interface{}) (*query.Result, error) {
+	pq, err := parser.ParseQuery(tx.Context, q)
 	if err != nil {
 		return nil, err
 	}
 
-	return pq.Exec(ctx, tx.Transaction, argsToParams(args))
+	return pq.Exec(tx.Transaction, argsToParams(args))
 }
 
 // QueryDocument runs the query and returns the first document.
 // If the query returns no error, QueryDocument returns database.ErrDocumentNotFound.
-func (tx *Tx) QueryDocument(ctx context.Context, q string, args ...interface{}) (document.Document, error) {
-	res, err := tx.Query(ctx, q, args...)
+func (tx *Tx) QueryDocument(q string, args ...interface{}) (document.Document, error) {
+	res, err := tx.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +168,8 @@ func (tx *Tx) QueryDocument(ctx context.Context, q string, args ...interface{}) 
 }
 
 // Exec a query against the database within tx and without returning the result.
-func (tx *Tx) Exec(ctx context.Context, q string, args ...interface{}) error {
-	res, err := tx.Query(ctx, q, args...)
+func (tx *Tx) Exec(q string, args ...interface{}) error {
+	res, err := tx.Query(q, args...)
 	if err != nil {
 		return err
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -1,7 +1,6 @@
 package genji_test
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -25,19 +24,17 @@ func ExampleTx() {
 	}
 	defer tx.Rollback()
 
-	ctx := context.Background()
-
-	err = tx.Exec(ctx, "CREATE TABLE IF NOT EXISTS user")
+	err = tx.Exec("CREATE TABLE IF NOT EXISTS user")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = tx.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
+	err = tx.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	d, err := tx.QueryDocument(ctx, "SELECT id, name, age FROM user WHERE name = ?", "foo")
+	d, err := tx.QueryDocument("SELECT id, name, age FROM user WHERE name = ?", "foo")
 	if err != nil {
 		panic(err)
 	}
@@ -77,9 +74,7 @@ func TestQueryDocument(t *testing.T) {
 	tx, err := db.Begin(true)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-
-	err = tx.Exec(ctx, `
+	err = tx.Exec(`
 			CREATE TABLE test;
 			INSERT INTO test (a, b) VALUES (1, 'foo'), (2, 'bar')
 		`)
@@ -90,7 +85,7 @@ func TestQueryDocument(t *testing.T) {
 		var a int
 		var b string
 
-		r, err := db.QueryDocument(ctx, "SELECT * FROM test")
+		r, err := db.QueryDocument("SELECT * FROM test")
 		err = document.Scan(r, &a, &b)
 		require.NoError(t, err)
 		require.Equal(t, 1, a)
@@ -100,7 +95,7 @@ func TestQueryDocument(t *testing.T) {
 		require.NoError(t, err)
 		defer tx.Rollback()
 
-		r, err = tx.QueryDocument(ctx, "SELECT * FROM test")
+		r, err = tx.QueryDocument("SELECT * FROM test")
 		require.NoError(t, err)
 		err = document.Scan(r, &a, &b)
 		require.NoError(t, err)
@@ -109,14 +104,14 @@ func TestQueryDocument(t *testing.T) {
 	})
 
 	t.Run("Should return an error if no document", func(t *testing.T) {
-		r, err := db.QueryDocument(ctx, "SELECT * FROM test WHERE a > 100")
+		r, err := db.QueryDocument("SELECT * FROM test WHERE a > 100")
 		require.Equal(t, database.ErrDocumentNotFound, err)
 		require.Nil(t, r)
 
 		tx, err := db.Begin(false)
 		require.NoError(t, err)
 		defer tx.Rollback()
-		r, err = tx.QueryDocument(ctx, "SELECT * FROM test WHERE a > 100")
+		r, err = tx.QueryDocument("SELECT * FROM test WHERE a > 100")
 		require.Equal(t, database.ErrDocumentNotFound, err)
 		require.Nil(t, r)
 	})

--- a/document/iterator.go
+++ b/document/iterator.go
@@ -13,7 +13,7 @@ var ErrStreamClosed = errors.New("stream closed")
 type Iterator interface {
 	// Iterate goes through all the documents and calls the given function by passing each one of them.
 	// If the given function returns an error, the iteration stops.
-	Iterate(func(d Document) error) error
+	Iterate(fn func(d Document) error) error
 }
 
 // NewIterator creates an iterator that iterates over documents.
@@ -37,8 +37,8 @@ func (rr documentsIterator) Iterate(fn func(d Document) error) error {
 }
 
 // The IteratorFunc type is an adapter to allow the use of ordinary functions as Iterators.
-// If f is a function with the appropriate signature, HandlerFunc(f) is a Handler that calls f.
-type IteratorFunc func(func(d Document) error) error
+// If f is a function with the appropriate signature, IteratorFunc(f) is an Iterator that calls f.
+type IteratorFunc func(fn func(d Document) error) error
 
 // Iterate calls f(fn).
 func (f IteratorFunc) Iterate(fn func(d Document) error) error {

--- a/document/iterator_test.go
+++ b/document/iterator_test.go
@@ -2,7 +2,6 @@ package document_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -20,19 +19,17 @@ func ExampleStream_First() {
 	}
 	defer db.Close()
 
-	ctx := context.Background()
-
-	err = db.Exec(ctx, "CREATE TABLE user")
+	err = db.Exec("CREATE TABLE user")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = db.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
+	err = db.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	result, err := db.Query(ctx, "SELECT id, name, age FROM user WHERE name = ?", "foo")
+	result, err := db.Query("SELECT id, name, age FROM user WHERE name = ?", "foo")
 	if err != nil {
 		panic(err)
 	}
@@ -75,15 +72,13 @@ func ExampleStream_Iterate() {
 	}
 	defer db.Close()
 
-	ctx := context.Background()
-
-	err = db.Exec(ctx, "CREATE TABLE IF NOT EXISTS user")
+	err = db.Exec("CREATE TABLE IF NOT EXISTS user")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for i := 1; i <= 10; i++ {
-		err = db.Exec(ctx, "INSERT INTO user VALUES ?", &User{
+		err = db.Exec("INSERT INTO user VALUES ?", &User{
 			ID:   int64(i),
 			Name: fmt.Sprintf("foo%d", i),
 			Age:  uint32(i * 10),
@@ -100,7 +95,7 @@ func ExampleStream_Iterate() {
 		}
 	}
 
-	result, err := db.Query(ctx, `SELECT id, name, age, address FROM user WHERE age >= 18`)
+	result, err := db.Query(`SELECT id, name, age, address FROM user WHERE age >= 18`)
 	if err != nil {
 		panic(err)
 	}

--- a/engine/badgerengine/engine.go
+++ b/engine/badgerengine/engine.go
@@ -3,6 +3,7 @@ package badgerengine
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/genjidb/genji/engine"
@@ -32,13 +33,13 @@ func NewEngine(opt badger.Options) (*Engine, error) {
 }
 
 // Begin creates a transaction using Badger's transaction API.
-func (e *Engine) Begin(writable bool) (engine.Transaction, error) {
-	tx := e.DB.NewTransaction(writable)
+func (e *Engine) Begin(ctx context.Context, opts engine.TxOptions) (engine.Transaction, error) {
+	tx := e.DB.NewTransaction(opts.Writable)
 
 	return &Transaction{
 		ng:       e,
 		tx:       tx,
-		writable: writable,
+		writable: opts.Writable,
 	}, nil
 }
 

--- a/engine/badgerengine/example_test.go
+++ b/engine/badgerengine/example_test.go
@@ -1,6 +1,7 @@
 package badgerengine_test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -12,6 +13,8 @@ import (
 )
 
 func Example() {
+	ctx := context.Background()
+
 	dir, err := ioutil.TempDir("", "badger")
 	if err != nil {
 		log.Fatal(err)
@@ -23,7 +26,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	db, err := genji.New(ng)
+	db, err := genji.New(ctx, ng)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/badgerengine/example_test.go
+++ b/engine/badgerengine/example_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func Example() {
-	ctx := context.Background()
-
 	dir, err := ioutil.TempDir("", "badger")
 	if err != nil {
 		log.Fatal(err)
@@ -26,7 +24,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	db, err := genji.New(ctx, ng)
+	db, err := genji.New(context.Background(), ng)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/badgerengine/store.go
+++ b/engine/badgerengine/store.go
@@ -127,7 +127,7 @@ func (s *Store) NextSequence() (uint64, error) {
 	return nb + 1, nil
 }
 
-// NewIterator uses a Badger iterator with default options.
+// Iterator uses a Badger iterator with default options.
 // Only one iterator is allowed per read-write transaction.
 func (s *Store) Iterator(opts engine.IteratorOptions) engine.Iterator {
 	prefix := buildKey(s.prefix, nil)

--- a/engine/badgerengine/store.go
+++ b/engine/badgerengine/store.go
@@ -129,19 +129,19 @@ func (s *Store) NextSequence() (uint64, error) {
 
 // NewIterator uses a Badger iterator with default options.
 // Only one iterator is allowed per read-write transaction.
-func (s *Store) NewIterator(cfg engine.IteratorConfig) engine.Iterator {
+func (s *Store) Iterator(opts engine.IteratorOptions) engine.Iterator {
 	prefix := buildKey(s.prefix, nil)
 
 	opt := badger.DefaultIteratorOptions
 	opt.Prefix = prefix
-	opt.Reverse = cfg.Reverse
+	opt.Reverse = opts.Reverse
 	it := s.tx.NewIterator(opt)
 
 	return &iterator{
 		storePrefix: s.prefix,
 		prefix:      prefix,
 		it:          it,
-		reverse:     cfg.Reverse,
+		reverse:     opts.Reverse,
 		item:        badgerItem{prefix: prefix},
 	}
 }
@@ -180,6 +180,10 @@ func (it *iterator) Valid() bool {
 
 func (it *iterator) Next() {
 	it.it.Next()
+}
+
+func (it *iterator) Err() error {
+	return nil
 }
 
 func (it *iterator) Item() engine.Item {

--- a/engine/boltengine/engine.go
+++ b/engine/boltengine/engine.go
@@ -2,6 +2,7 @@
 package boltengine
 
 import (
+	"context"
 	"os"
 
 	"github.com/genjidb/genji/engine"
@@ -30,15 +31,15 @@ func NewEngine(path string, mode os.FileMode, opts *bolt.Options) (*Engine, erro
 }
 
 // Begin creates a transaction using Bolt's transaction API.
-func (e *Engine) Begin(writable bool) (engine.Transaction, error) {
-	tx, err := e.DB.Begin(writable)
+func (e *Engine) Begin(ctx context.Context, opts engine.TxOptions) (engine.Transaction, error) {
+	tx, err := e.DB.Begin(opts.Writable)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Transaction{
 		tx:       tx,
-		writable: writable,
+		writable: opts.Writable,
 	}, nil
 }
 

--- a/engine/boltengine/example_test.go
+++ b/engine/boltengine/example_test.go
@@ -1,6 +1,7 @@
 package boltengine_test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -36,7 +37,7 @@ func ExampleNewEngine() {
 		log.Fatal(err)
 	}
 
-	db, err := genji.New(ng)
+	db, err := genji.New(context.Background(), ng)
 	defer db.Close()
 	if err != nil {
 		log.Fatal(err)

--- a/engine/boltengine/store.go
+++ b/engine/boltengine/store.go
@@ -71,7 +71,7 @@ func (s *Store) NextSequence() (uint64, error) {
 	return s.bucket.NextSequence()
 }
 
-// NewIterator uses the bucket cursor.
+// Iterator uses the Bolt bucket cursor.
 func (s *Store) Iterator(opts engine.IteratorOptions) engine.Iterator {
 	return &iterator{
 		c:       s.bucket.Cursor(),

--- a/engine/boltengine/store.go
+++ b/engine/boltengine/store.go
@@ -72,10 +72,10 @@ func (s *Store) NextSequence() (uint64, error) {
 }
 
 // NewIterator uses the bucket cursor.
-func (s *Store) NewIterator(cfg engine.IteratorConfig) engine.Iterator {
+func (s *Store) Iterator(opts engine.IteratorOptions) engine.Iterator {
 	return &iterator{
 		c:       s.bucket.Cursor(),
-		reverse: cfg.Reverse,
+		reverse: opts.Reverse,
 	}
 }
 
@@ -114,6 +114,10 @@ func (it *iterator) Next() {
 	} else {
 		it.item.k, it.item.v = it.c.Next()
 	}
+}
+
+func (it *iterator) Err() error {
+	return nil
 }
 
 func (it *iterator) Item() engine.Item {

--- a/engine/enginetest/benchmark.go
+++ b/engine/enginetest/benchmark.go
@@ -47,11 +47,13 @@ func BenchmarkStoreScan(b *testing.B, builder Builder) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				it := st.NewIterator(engine.IteratorConfig{})
+				it := st.Iterator(engine.IteratorOptions{})
 				for it.Seek(nil); it.Valid(); it.Next() {
 				}
-				err := it.Close()
-				if err != nil {
+				if err := it.Err(); err != nil {
+					require.NoError(b, err)
+				}
+				if err := it.Close(); err != nil {
 					require.NoError(b, err)
 				}
 			}

--- a/engine/enginetest/testing.go
+++ b/engine/enginetest/testing.go
@@ -71,7 +71,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 	}()
 
 	t.Run("Commit on read-only transaction should fail", func(t *testing.T) {
-		tx, err := ng.Begin(false)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: false,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -80,7 +82,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 	})
 
 	t.Run("Commit after rollback should fail", func(t *testing.T) {
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -92,7 +96,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 	})
 
 	t.Run("Rollback after commit should not fail", func(t *testing.T) {
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -104,7 +110,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 	})
 
 	t.Run("Commit after commit should fail", func(t *testing.T) {
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -116,7 +124,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 	})
 
 	t.Run("Rollback after rollback should not fail", func(t *testing.T) {
-		tx, err := ng.Begin(false)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: false,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -128,7 +138,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 	})
 
 	t.Run("Read-Only write attempts", func(t *testing.T) {
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 
 		// create store for testing store methods
@@ -139,7 +151,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 		require.NoError(t, err)
 
 		// create a new read-only transaction
-		tx, err = ng.Begin(false)
+		tx, err = ng.Begin(context.Background(), engine.TxOptions{
+			Writable: false,
+		})
 		defer tx.Rollback()
 
 		// fetch the store and the index
@@ -214,7 +228,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 
 				if test.initFn != nil {
 					func() {
-						tx, err := ng.Begin(true)
+						tx, err := ng.Begin(context.Background(), engine.TxOptions{
+							Writable: true,
+						})
 						require.NoError(t, err)
 						defer tx.Rollback()
 
@@ -225,7 +241,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 					}()
 				}
 
-				tx, err := ng.Begin(true)
+				tx, err := ng.Begin(context.Background(), engine.TxOptions{
+					Writable: true,
+				})
 				require.NoError(t, err)
 				defer tx.Rollback()
 
@@ -235,7 +253,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 				err = tx.Rollback()
 				require.NoError(t, err)
 
-				tx, err = ng.Begin(true)
+				tx, err = ng.Begin(context.Background(), engine.TxOptions{
+					Writable: true,
+				})
 				require.NoError(t, err)
 				defer tx.Rollback()
 
@@ -254,7 +274,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 			t.Run(test.name+"/commit", func(t *testing.T) {
 				if test.initFn != nil {
 					func() {
-						tx, err := ng.Begin(true)
+						tx, err := ng.Begin(context.Background(), engine.TxOptions{
+							Writable: true,
+						})
 						require.NoError(t, err)
 						defer tx.Rollback()
 
@@ -265,7 +287,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 					}()
 				}
 
-				tx, err := ng.Begin(true)
+				tx, err := ng.Begin(context.Background(), engine.TxOptions{
+					Writable: true,
+				})
 				require.NoError(t, err)
 				defer tx.Rollback()
 
@@ -275,7 +299,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 				err = tx.Commit()
 				require.NoError(t, err)
 
-				tx, err = ng.Begin(true)
+				tx, err = ng.Begin(context.Background(), engine.TxOptions{
+					Writable: true,
+				})
 				require.NoError(t, err)
 				defer tx.Rollback()
 
@@ -306,7 +332,9 @@ func TestTransactionCommitRollback(t *testing.T, builder Builder) {
 					require.NoError(t, ng.Close())
 				}()
 
-				tx, err := ng.Begin(true)
+				tx, err := ng.Begin(context.Background(), engine.TxOptions{
+					Writable: true,
+				})
 				require.NoError(t, err)
 				defer tx.Rollback()
 
@@ -329,7 +357,9 @@ func TestTransactionCreateStore(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -348,7 +378,9 @@ func TestTransactionCreateStore(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -368,7 +400,9 @@ func TestTransactionStore(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(false)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: false,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -383,7 +417,9 @@ func TestTransactionStore(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -426,7 +462,9 @@ func TestTransactionDropStore(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -447,7 +485,9 @@ func TestTransactionDropStore(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -458,7 +498,9 @@ func TestTransactionDropStore(t *testing.T, builder Builder) {
 
 func storeBuilder(t testing.TB, builder Builder) (engine.Store, func()) {
 	ng, cleanup := builder()
-	tx, err := ng.Begin(true)
+	tx, err := ng.Begin(context.Background(), engine.TxOptions{
+		Writable: true,
+	})
 	require.NoError(t, err)
 	err = tx.CreateStore([]byte("test"))
 	require.NoError(t, err)
@@ -480,13 +522,14 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			st, cleanup := storeBuilder(t, builder)
 			defer cleanup()
 
-			it := st.NewIterator(engine.IteratorConfig{Reverse: reverse})
+			it := st.Iterator(engine.IteratorOptions{Reverse: reverse})
 			defer it.Close()
 			i := 0
 
 			for it.Seek(nil); it.Valid(); it.Next() {
 				i++
 			}
+			require.NoError(t, it.Err())
 			require.Zero(t, i)
 		}
 		t.Run("Reverse: false", func(t *testing.T) {
@@ -508,7 +551,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 
 		var i uint8 = 1
 		var count int
-		it := st.NewIterator(engine.IteratorConfig{})
+		it := st.Iterator(engine.IteratorOptions{})
 		defer it.Close()
 
 		for it.Seek(nil); it.Valid(); it.Next() {
@@ -520,6 +563,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			i++
 			count++
 		}
+		require.NoError(t, it.Err())
 
 		require.Equal(t, count, 10)
 	})
@@ -535,7 +579,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 
 		var i uint8 = 10
 		var count int
-		it := st.NewIterator(engine.IteratorConfig{Reverse: true})
+		it := st.Iterator(engine.IteratorOptions{Reverse: true})
 		defer it.Close()
 
 		for it.Seek(nil); it.Valid(); it.Next() {
@@ -547,6 +591,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			i--
 			count++
 		}
+		require.NoError(t, it.Err())
 		require.Equal(t, 10, count)
 	})
 
@@ -561,7 +606,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 
 		var i uint8 = 4
 		var count int
-		it := st.NewIterator(engine.IteratorConfig{})
+		it := st.Iterator(engine.IteratorOptions{})
 		defer it.Close()
 
 		for it.Seek([]byte{i}); it.Valid(); it.Next() {
@@ -573,6 +618,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			i++
 			count++
 		}
+		require.NoError(t, it.Err())
 		require.Equal(t, 7, count)
 	})
 
@@ -587,7 +633,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 
 		var i uint8 = 4
 		var count int
-		it := st.NewIterator(engine.IteratorConfig{Reverse: true})
+		it := st.Iterator(engine.IteratorOptions{Reverse: true})
 		defer it.Close()
 
 		for it.Seek([]byte{i}); it.Valid(); it.Next() {
@@ -599,6 +645,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			i--
 			count++
 		}
+		require.NoError(t, it.Err())
 		require.Equal(t, 4, count)
 	})
 
@@ -613,7 +660,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 		require.NoError(t, err)
 
 		called := false
-		it := st.NewIterator(engine.IteratorConfig{})
+		it := st.Iterator(engine.IteratorOptions{})
 		defer it.Close()
 
 		for it.Seek([]byte{2}); it.Valid(); it.Next() {
@@ -624,6 +671,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			require.Equal(t, []byte{3}, v)
 			called = true
 		}
+		require.NoError(t, it.Err())
 
 		require.True(t, called)
 	})
@@ -639,7 +687,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 		require.NoError(t, err)
 
 		called := false
-		it := st.NewIterator(engine.IteratorConfig{Reverse: true})
+		it := st.Iterator(engine.IteratorOptions{Reverse: true})
 		defer it.Close()
 
 		for it.Seek([]byte{2}); it.Valid(); it.Next() {
@@ -650,6 +698,7 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 			require.Equal(t, []byte{1}, v)
 			called = true
 		}
+		require.NoError(t, it.Err())
 		require.True(t, called)
 	})
 
@@ -661,11 +710,12 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 		err := st.Put(k, []byte{1})
 		require.NoError(t, err)
 
-		it := st.NewIterator(engine.IteratorConfig{Reverse: true})
+		it := st.Iterator(engine.IteratorOptions{Reverse: true})
 		defer it.Close()
 
 		it.Seek(nil)
 
+		require.NoError(t, it.Err())
 		require.True(t, it.Valid())
 		require.Equal(t, it.Item().Key(), k)
 	})
@@ -813,9 +863,10 @@ func TestStoreTruncate(t *testing.T, builder Builder) {
 		err = st.Truncate()
 		require.NoError(t, err)
 
-		it := st.NewIterator(engine.IteratorConfig{})
+		it := st.Iterator(engine.IteratorOptions{})
 		defer it.Close()
 		it.Seek(nil)
+		require.NoError(t, it.Err())
 		require.False(t, it.Valid())
 	})
 }
@@ -829,14 +880,19 @@ func TestStoreNextSequence(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		tx, err := ng.Begin(true)
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
+
 		require.NoError(t, err)
 		err = tx.CreateStore([]byte("test"))
 		require.NoError(t, err)
 		err = tx.Commit()
 		require.NoError(t, err)
 
-		tx, err = ng.Begin(false)
+		tx, err = ng.Begin(context.Background(), engine.TxOptions{
+			Writable: false,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -864,7 +920,10 @@ func TestStoreNextSequence(t *testing.T, builder Builder) {
 		defer func() {
 			require.NoError(t, ng.Close())
 		}()
-		tx, err := ng.Begin(true)
+
+		tx, err := ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 
 		require.NoError(t, err)
 		err = tx.CreateStore([]byte("test"))
@@ -878,7 +937,9 @@ func TestStoreNextSequence(t *testing.T, builder Builder) {
 		err = tx.Commit()
 		require.NoError(t, err)
 
-		tx, err = ng.Begin(true)
+		tx, err = ng.Begin(context.Background(), engine.TxOptions{
+			Writable: true,
+		})
 		require.NoError(t, err)
 		defer tx.Rollback()
 
@@ -892,8 +953,6 @@ func TestStoreNextSequence(t *testing.T, builder Builder) {
 
 // TestQueries test simple queries against the engine.
 func TestQueries(t *testing.T, builder Builder) {
-	ctx := context.Background()
-
 	t.Run("SELECT", func(t *testing.T) {
 		ng, cleanup := builder()
 		defer cleanup()
@@ -901,12 +960,10 @@ func TestQueries(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
-		ctx := context.Background()
-
-		st, err := db.Query(ctx, `
+		st, err := db.Query(`
 			CREATE TABLE test;
 			INSERT INTO test (a) VALUES (1), (2), (3), (4);
 			SELECT * FROM test;
@@ -919,7 +976,7 @@ func TestQueries(t *testing.T, builder Builder) {
 		require.NoError(t, err)
 
 		t.Run("ORDER BY", func(t *testing.T) {
-			st, err := db.Query(ctx, "SELECT * FROM test ORDER BY a DESC")
+			st, err := db.Query("SELECT * FROM test ORDER BY a DESC")
 			require.NoError(t, err)
 			defer st.Close()
 
@@ -943,10 +1000,10 @@ func TestQueries(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `
+		err = db.Exec(`
 			CREATE TABLE test;
 			INSERT INTO test (a) VALUES (1), (2), (3), (4);
 		`)
@@ -960,10 +1017,10 @@ func TestQueries(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
-		st, err := db.Query(ctx, `
+		st, err := db.Query(`
 				CREATE TABLE test;
 				INSERT INTO test (a) VALUES (1), (2), (3), (4);
 				UPDATE test SET a = 5;
@@ -984,22 +1041,22 @@ func TestQueries(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, "CREATE TABLE test")
+		err = db.Exec("CREATE TABLE test")
 		require.NoError(t, err)
 
 		err = db.Update(func(tx *genji.Tx) error {
 			for i := 1; i < 200; i++ {
-				err = tx.Exec(ctx, "INSERT INTO test (a) VALUES (?)", i)
+				err = tx.Exec("INSERT INTO test (a) VALUES (?)", i)
 				require.NoError(t, err)
 			}
 			return nil
 		})
 		require.NoError(t, err)
 
-		st, err := db.Query(ctx, `
+		st, err := db.Query(`
 			DELETE FROM test WHERE a > 2;
 			SELECT * FROM test;
 		`)
@@ -1013,8 +1070,6 @@ func TestQueries(t *testing.T, builder Builder) {
 
 // TestQueriesSameTransaction test simple queries in the same transaction.
 func TestQueriesSameTransaction(t *testing.T, builder Builder) {
-	ctx := context.Background()
-
 	t.Run("SELECT", func(t *testing.T) {
 		ng, cleanup := builder()
 		defer cleanup()
@@ -1022,11 +1077,11 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
 		err = db.Update(func(tx *genji.Tx) error {
-			st, err := tx.Query(ctx, `
+			st, err := tx.Query(`
 				CREATE TABLE test;
 				INSERT INTO test (a) VALUES (1), (2), (3), (4);
 				SELECT * FROM test;
@@ -1048,11 +1103,11 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
 		err = db.Update(func(tx *genji.Tx) error {
-			err = tx.Exec(ctx, `
+			err = tx.Exec(`
 			CREATE TABLE test;
 			INSERT INTO test (a) VALUES (1), (2), (3), (4);
 		`)
@@ -1069,11 +1124,11 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
 		err = db.Update(func(tx *genji.Tx) error {
-			st, err := tx.Query(ctx, `
+			st, err := tx.Query(`
 				CREATE TABLE test;
 				INSERT INTO test (a) VALUES (1), (2), (3), (4);
 				UPDATE test SET a = 5;
@@ -1097,11 +1152,11 @@ func TestQueriesSameTransaction(t *testing.T, builder Builder) {
 			require.NoError(t, ng.Close())
 		}()
 
-		db, err := genji.New(ng)
+		db, err := genji.New(context.Background(), ng)
 		require.NoError(t, err)
 
 		err = db.Update(func(tx *genji.Tx) error {
-			st, err := tx.Query(ctx, `
+			st, err := tx.Query(`
 			CREATE TABLE test;
 			INSERT INTO test (a) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 			DELETE FROM test WHERE a > 2;

--- a/engine/memoryengine/engine.go
+++ b/engine/memoryengine/engine.go
@@ -1,6 +1,7 @@
 package memoryengine
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -32,8 +33,8 @@ func NewEngine() *Engine {
 }
 
 // Begin creates a transaction.
-func (ng *Engine) Begin(writable bool) (engine.Transaction, error) {
-	if writable {
+func (ng *Engine) Begin(ctx context.Context, opts engine.TxOptions) (engine.Transaction, error) {
+	if opts.Writable {
 		ng.mu.Lock()
 	} else {
 		ng.mu.RLock()
@@ -43,7 +44,7 @@ func (ng *Engine) Begin(writable bool) (engine.Transaction, error) {
 		return nil, errors.New("engine closed")
 	}
 
-	return &transaction{ng: ng, writable: writable}, nil
+	return &transaction{ng: ng, writable: opts.Writable}, nil
 }
 
 // Close the engine.

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -171,11 +171,11 @@ func (s *storeTx) NextSequence() (uint64, error) {
 	return s.tx.ng.sequences[s.name], nil
 }
 
-func (s *storeTx) NewIterator(cfg engine.IteratorConfig) engine.Iterator {
+func (s *storeTx) Iterator(opts engine.IteratorOptions) engine.Iterator {
 	return &iterator{
 		tx:      s.tx,
 		tr:      s.tr,
-		reverse: cfg.Reverse,
+		reverse: opts.Reverse,
 		ch:      make(chan *item),
 		closed:  make(chan struct{}),
 	}
@@ -264,6 +264,10 @@ func (it *iterator) Valid() bool {
 // Read the next item from the goroutine
 func (it *iterator) Next() {
 	it.item = <-it.ch
+}
+
+func (it *iterator) Err() error {
+	return nil
 }
 
 func (it *iterator) Item() engine.Item {

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -171,6 +171,7 @@ func (s *storeTx) NextSequence() (uint64, error) {
 	return s.tx.ng.sequences[s.name], nil
 }
 
+// Iterator creates an iterator with the given options.
 func (s *storeTx) Iterator(opts engine.IteratorOptions) engine.Iterator {
 	return &iterator{
 		tx:      s.tx,

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,6 @@
 package genji_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -28,40 +27,38 @@ func Example() {
 	}
 	defer db.Close()
 
-	ctx := context.Background()
-
 	// Create a table. Genji tables are schemaless by default, you don't need to specify a schema.
-	err = db.Exec(ctx, "CREATE TABLE user")
+	err = db.Exec("CREATE TABLE user")
 	if err != nil {
 		panic(err)
 	}
 
 	// Create an index.
-	err = db.Exec(ctx, "CREATE INDEX idx_user_name ON user (name)")
+	err = db.Exec("CREATE INDEX idx_user_name ON user (name)")
 	if err != nil {
 		panic(err)
 	}
 
 	// Insert some data
-	err = db.Exec(ctx, "INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
+	err = db.Exec("INSERT INTO user (id, name, age) VALUES (?, ?, ?)", 10, "foo", 15)
 	if err != nil {
 		panic(err)
 	}
 
 	// Insert some data using document notation
-	err = db.Exec(ctx, `INSERT INTO user VALUES {id: 12, "name": "bar", age: ?, address: {city: "Lyon", zipcode: "69001"}}`, 16)
+	err = db.Exec(`INSERT INTO user VALUES {id: 12, "name": "bar", age: ?, address: {city: "Lyon", zipcode: "69001"}}`, 16)
 	if err != nil {
 		panic(err)
 	}
 
 	// Structs can be used to describe a document
-	err = db.Exec(ctx, "INSERT INTO user VALUES ?, ?", &User{ID: 1, Name: "baz", Age: 100}, &User{ID: 2, Name: "bat"})
+	err = db.Exec("INSERT INTO user VALUES ?, ?", &User{ID: 1, Name: "baz", Age: 100}, &User{ID: 2, Name: "bat"})
 	if err != nil {
 		panic(err)
 	}
 
 	// Query some documents
-	stream, err := db.Query(ctx, "SELECT * FROM user WHERE id > ?", 1)
+	stream, err := db.Query("SELECT * FROM user WHERE id > ?", 1)
 	if err != nil {
 		panic(err)
 	}

--- a/fuzz/sqlparser.go
+++ b/fuzz/sqlparser.go
@@ -1,7 +1,6 @@
 package fuzz
 
 import (
-	"context"
 	"strings"
 
 	"github.com/genjidb/genji/sql/parser"
@@ -10,7 +9,7 @@ import (
 func FuzzParseQuery(data []byte) int {
 	var b strings.Builder
 	b.Write(data)
-	q, err := parser.ParseQuery(context.Background(), b.String())
+	q, err := parser.ParseQuery(b.String())
 	if err != nil {
 		return 0
 	}

--- a/index/index.go
+++ b/index/index.go
@@ -296,7 +296,6 @@ func (idx *Index) iterate(st engine.Store, pivot document.Value, reverse bool, f
 		if err != nil {
 			return err
 		}
-
 	}
 	if err := it.Err(); err != nil {
 		return err

--- a/index/index.go
+++ b/index/index.go
@@ -282,7 +282,7 @@ func (idx *Index) iterate(st engine.Store, pivot document.Value, reverse bool, f
 		}
 	}
 
-	it := st.NewIterator(engine.IteratorConfig{Reverse: reverse})
+	it := st.Iterator(engine.IteratorOptions{Reverse: reverse})
 	defer it.Close()
 
 	for it.Seek(seek); it.Valid(); it.Next() {
@@ -296,6 +296,10 @@ func (idx *Index) iterate(st engine.Store, pivot document.Value, reverse bool, f
 		if err != nil {
 			return err
 		}
+
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -2,12 +2,14 @@
 package index_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/genjidb/genji/document"
+	"github.com/genjidb/genji/engine"
 	"github.com/genjidb/genji/engine/memoryengine"
 	"github.com/genjidb/genji/index"
 	"github.com/genjidb/genji/key"
@@ -16,7 +18,9 @@ import (
 
 func getIndex(t testing.TB, unique bool) (*index.Index, func()) {
 	ng := memoryengine.NewEngine()
-	tx, err := ng.Begin(true)
+	tx, err := ng.Begin(context.Background(), engine.TxOptions{
+		Writable: true,
+	})
 	require.NoError(t, err)
 
 	idx := index.NewIndex(tx, "foo", index.Options{Unique: unique})

--- a/new.go
+++ b/new.go
@@ -19,6 +19,6 @@ func New(ctx context.Context, ng engine.Engine) (*DB, error) {
 
 	return &DB{
 		DB:      db,
-		Context: ctx,
+		Context: context.Background(),
 	}, nil
 }

--- a/new.go
+++ b/new.go
@@ -3,19 +3,22 @@
 package genji
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document/encoding/msgpack"
 	"github.com/genjidb/genji/engine"
 )
 
 // New initializes the DB using the given engine.
-func New(ng engine.Engine) (*DB, error) {
-	db, err := database.New(ng, database.Options{Codec: msgpack.NewCodec()})
+func New(ctx context.Context, ng engine.Engine) (*DB, error) {
+	db, err := database.New(ctx, ng, database.Options{Codec: msgpack.NewCodec()})
 	if err != nil {
 		return nil, err
 	}
 
 	return &DB{
-		DB: db,
+		DB:      db,
+		Context: ctx,
 	}, nil
 }

--- a/new_wasm.go
+++ b/new_wasm.go
@@ -19,6 +19,6 @@ func New(ctx context.Context, ng engine.Engine) (*DB, error) {
 
 	return &DB{
 		DB:      db,
-		Context: ctx,
+		Context: context.Background(),
 	}, nil
 }

--- a/new_wasm.go
+++ b/new_wasm.go
@@ -3,19 +3,22 @@
 package genji
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/database"
 	"github.com/genjidb/genji/document/encoding/custom"
 	"github.com/genjidb/genji/engine"
 )
 
 // New initializes the DB using the given engine.
-func New(ng engine.Engine) (*DB, error) {
-	db, err := database.New(ng, database.Options{Codec: custom.NewCodec()})
+func New(ctx context.Context, ng engine.Engine) (*DB, error) {
+	db, err := database.New(ctx, ng, database.Options{Codec: custom.NewCodec()})
 	if err != nil {
 		return nil, err
 	}
 
 	return &DB{
-		DB: db,
+		DB:      db,
+		Context: ctx,
 	}, nil
 }

--- a/open.go
+++ b/open.go
@@ -3,6 +3,8 @@
 package genji
 
 import (
+	"context"
+
 	"github.com/genjidb/genji/engine"
 	"github.com/genjidb/genji/engine/boltengine"
 	"github.com/genjidb/genji/engine/memoryengine"
@@ -25,5 +27,6 @@ func Open(path string) (*DB, error) {
 		return nil, err
 	}
 
-	return New(ng)
+	ctx := context.Background()
+	return New(ctx, ng)
 }

--- a/sql/driver/driver.go
+++ b/sql/driver/driver.go
@@ -92,7 +92,7 @@ func (c *conn) Prepare(q string) (driver.Stmt, error) {
 
 // PrepareContext returns a prepared statement, bound to this connection.
 func (c *conn) PrepareContext(ctx context.Context, q string) (driver.Stmt, error) {
-	pq, err := parser.ParseQuery(ctx, q)
+	pq, err := parser.ParseQuery(q)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/parser/alter_test.go
+++ b/sql/parser/alter_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/database"
@@ -25,7 +24,7 @@ func TestParserAlterTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return
@@ -76,7 +75,7 @@ func TestParserAlterTableAddColumn(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/parser/create_test.go
+++ b/sql/parser/create_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/database"
@@ -183,7 +182,7 @@ func TestParserCreateTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return
@@ -211,7 +210,7 @@ func TestParserCreateIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/parser/delete_test.go
+++ b/sql/parser/delete_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/planner"
@@ -29,7 +28,7 @@ func TestParserDelete(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			require.NoError(t, err)
 			require.Len(t, q.Statements, 1)
 			require.EqualValues(t, test.expected, q.Statements[0])

--- a/sql/parser/drop_test.go
+++ b/sql/parser/drop_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/query"
@@ -23,7 +22,7 @@ func TestParserDrop(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/parser/explain_test.go
+++ b/sql/parser/explain_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/planner"
@@ -22,7 +21,7 @@ func TestParserExplain(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/parser/insert_test.go
+++ b/sql/parser/insert_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/query"
@@ -80,7 +79,7 @@ func TestParserInsert(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.fails {
 				require.Error(t, err)
 				return

--- a/sql/parser/parser.go
+++ b/sql/parser/parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -37,8 +36,8 @@ func NewParserWithOptions(r io.Reader, opts *Options) *Parser {
 }
 
 // ParseQuery parses a query string and returns its AST representation.
-func ParseQuery(ctx context.Context, s string) (query.Query, error) {
-	return NewParser(strings.NewReader(s)).ParseQuery(ctx)
+func ParseQuery(s string) (query.Query, error) {
+	return NewParser(strings.NewReader(s)).ParseQuery()
 }
 
 // ParsePath parses the path of a value in a document.
@@ -47,17 +46,11 @@ func ParsePath(s string) (document.ValuePath, error) {
 }
 
 // ParseQuery parses a Genji SQL string and returns a Query.
-func (p *Parser) ParseQuery(ctx context.Context) (query.Query, error) {
+func (p *Parser) ParseQuery() (query.Query, error) {
 	var statements []query.Statement
 	semi := true
 
 	for {
-		select {
-		case <-ctx.Done():
-			return query.Query{}, ctx.Err()
-		default:
-		}
-
 		if tok, pos, lit := p.ScanIgnoreWhitespace(); tok == scanner.EOF {
 			return query.New(statements...), nil
 		} else if tok == scanner.SEMICOLON {

--- a/sql/parser/parser_test.go
+++ b/sql/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,7 +37,7 @@ func TestParserMultiStatement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			require.NoError(t, err)
 			require.EqualValues(t, test.expected, q.Statements)
 		})
@@ -48,6 +47,6 @@ func TestParserMultiStatement(t *testing.T) {
 func TestParserDivideByZero(t *testing.T) {
 	// See https://github.com/genjidb/genji/issues/268
 	require.NotPanics(t, func() {
-		_, _ = ParseQuery(context.Background(), "SELECT * FROM t LIMIT 0 % .5")
+		_, _ = ParseQuery("SELECT * FROM t LIMIT 0 % .5")
 	})
 }

--- a/sql/parser/reindex_test.go
+++ b/sql/parser/reindex_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/query"
@@ -22,7 +21,7 @@ func TestParserReIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/parser/select_test.go
+++ b/sql/parser/select_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/planner"
@@ -231,7 +230,7 @@ func TestParserSelect(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if !test.mustFail {
 				require.NoError(t, err)
 				require.Len(t, q.Statements, 1)

--- a/sql/parser/transaction_test.go
+++ b/sql/parser/transaction_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/query"
@@ -28,7 +27,7 @@ func TestParserTransactions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.s, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/parser/update_test.go
+++ b/sql/parser/update_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji/sql/planner"
@@ -127,7 +126,7 @@ func TestParserUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			q, err := ParseQuery(context.Background(), test.s)
+			q, err := ParseQuery(test.s)
 			if test.errored {
 				require.Error(t, err)
 				return

--- a/sql/planner/explain.go
+++ b/sql/planner/explain.go
@@ -1,7 +1,6 @@
 package planner
 
 import (
-	"context"
 	"errors"
 
 	"github.com/genjidb/genji/database"
@@ -21,7 +20,7 @@ type ExplainStmt struct {
 // If the statement is a tree, Bind and Optimize will be called prior to
 // displaying all the operations.
 // Explain currently only works on SELECT, UPDATE and DELETE statements.
-func (s *ExplainStmt) Run(ctx context.Context, tx *database.Transaction, params []expr.Param) (query.Result, error) {
+func (s *ExplainStmt) Run(tx *database.Transaction, params []expr.Param) (query.Result, error) {
 	switch t := s.Statement.(type) {
 	case *Tree:
 		err := Bind(t, tx, params)

--- a/sql/planner/explain_test.go
+++ b/sql/planner/explain_test.go
@@ -1,7 +1,6 @@
 package planner_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -40,17 +39,15 @@ func TestExplainStmt(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			ctx := context.Background()
-
-			err = db.Exec(ctx, "CREATE TABLE test (k INTEGER PRIMARY KEY)")
+			err = db.Exec("CREATE TABLE test (k INTEGER PRIMARY KEY)")
 			require.NoError(t, err)
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 						CREATE INDEX idx_a ON test (a);
 						CREATE UNIQUE INDEX idx_b ON test (b);
 					`)
 			require.NoError(t, err)
 
-			d, err := db.QueryDocument(ctx, test.query)
+			d, err := db.QueryDocument(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return

--- a/sql/planner/optimizer_test.go
+++ b/sql/planner/optimizer_test.go
@@ -1,7 +1,6 @@
 package planner_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -347,7 +346,7 @@ func TestUseIndexBasedOnSelectionNodeRule(t *testing.T) {
 			require.NoError(t, err)
 			defer tx.Rollback()
 
-			err = tx.Exec(context.Background(), `
+			err = tx.Exec(`
 				CREATE TABLE foo;
 				CREATE INDEX idx_foo_a ON foo(a);
 				CREATE INDEX idx_foo_b ON foo(b);

--- a/sql/planner/replacement.go
+++ b/sql/planner/replacement.go
@@ -117,7 +117,7 @@ func (u *resumableIterator) Iterate(fn func(d document.Document) error) error {
 	var d encodedDocumentWithKey
 	var err error
 
-	it := u.store.NewIterator(engine.IteratorConfig{})
+	it := u.store.Iterator(engine.IteratorOptions{})
 	defer it.Close()
 
 	var buf []byte
@@ -135,6 +135,9 @@ func (u *resumableIterator) Iterate(fn func(d document.Document) error) error {
 		if err != nil {
 			return err
 		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/sql/planner/tree.go
+++ b/sql/planner/tree.go
@@ -6,7 +6,6 @@
 package planner
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/genjidb/genji/database"
@@ -58,7 +57,7 @@ func NewTree(n Node) *Tree {
 
 // Run implements the query.Statement interface.
 // It binds the tree to the database resources and executes it.
-func (t *Tree) Run(ctx context.Context, tx *database.Transaction, params []expr.Param) (query.Result, error) {
+func (t *Tree) Run(tx *database.Transaction, params []expr.Param) (query.Result, error) {
 	err := Bind(t, tx, params)
 	if err != nil {
 		return query.Result{}, err

--- a/sql/query/alter.go
+++ b/sql/query/alter.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"context"
 	"errors"
 
 	"github.com/genjidb/genji/database"
@@ -21,7 +20,7 @@ func (stmt AlterStmt) IsReadOnly() bool {
 
 // Run runs the ALTER TABLE statement in the given transaction.
 // It implements the Statement interface.
-func (stmt AlterStmt) Run(ctx context.Context, tx *database.Transaction, _ []expr.Param) (Result, error) {
+func (stmt AlterStmt) Run(tx *database.Transaction, _ []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {
@@ -52,7 +51,7 @@ func (stmt AlterTableAddField) IsReadOnly() bool {
 
 // Run runs the ALTER TABLE ADD FIELD statement in the given transaction.
 // It implements the Statement interface.
-func (stmt AlterTableAddField) Run(ctx context.Context, tx *database.Transaction, _ []expr.Param) (Result, error) {
+func (stmt AlterTableAddField) Run(tx *database.Transaction, _ []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {

--- a/sql/query/alter_test.go
+++ b/sql/query/alter_test.go
@@ -1,7 +1,6 @@
 package query_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -12,38 +11,36 @@ import (
 )
 
 func TestAlterTable(t *testing.T) {
-	ctx := context.Background()
-
 	db, err := genji.Open(":memory:")
 	require.NoError(t, err)
 	defer db.Close()
 
-	err = db.Exec(ctx, "CREATE TABLE foo")
+	err = db.Exec("CREATE TABLE foo")
 	require.NoError(t, err)
 
 	// Insert some data into foo
-	err = db.Exec(ctx, `INSERT INTO foo VALUES {name: "John Doe", age: 99}`)
+	err = db.Exec(`INSERT INTO foo VALUES {name: "John Doe", age: 99}`)
 	require.NoError(t, err)
 
 	// Renaming the table to the same name should fail.
-	err = db.Exec(ctx, "ALTER TABLE foo RENAME TO foo")
+	err = db.Exec("ALTER TABLE foo RENAME TO foo")
 	require.EqualError(t, err, database.ErrTableAlreadyExists.Error())
 
-	err = db.Exec(ctx, "ALTER TABLE foo RENAME TO bar")
+	err = db.Exec("ALTER TABLE foo RENAME TO bar")
 	require.NoError(t, err)
 
 	// Selecting from the old name should fail.
-	err = db.Exec(ctx, "SELECT * FROM foo")
+	err = db.Exec("SELECT * FROM foo")
 	if !errors.Is(err, database.ErrTableNotFound) {
 		require.Equal(t, err, database.ErrTableNotFound)
 	}
 
-	d, err := db.QueryDocument(ctx, "SELECT * FROM bar")
+	d, err := db.QueryDocument("SELECT * FROM bar")
 	data, err := document.MarshalJSON(d)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"name": "John Doe", "age": 99}`, string(data))
 
 	// Renaming a read-only table should fail
-	err = db.Exec(ctx, "ALTER TABLE __genji_tables RENAME TO bar")
+	err = db.Exec("ALTER TABLE __genji_tables RENAME TO bar")
 	require.Error(t, err)
 }

--- a/sql/query/create.go
+++ b/sql/query/create.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"context"
 	"errors"
 
 	"github.com/genjidb/genji/database"
@@ -23,7 +22,7 @@ func (stmt CreateTableStmt) IsReadOnly() bool {
 
 // Run runs the Create table statement in the given transaction.
 // It implements the Statement interface.
-func (stmt CreateTableStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt CreateTableStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {
@@ -60,7 +59,7 @@ func (stmt CreateIndexStmt) IsReadOnly() bool {
 
 // Run runs the Create index statement in the given transaction.
 // It implements the Statement interface.
-func (stmt CreateIndexStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt CreateIndexStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {

--- a/sql/query/create_test.go
+++ b/sql/query/create_test.go
@@ -1,7 +1,6 @@
 package query_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -18,8 +17,6 @@ func parsePath(t testing.TB, str string) document.ValuePath {
 }
 
 func TestCreateTable(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name  string
 		query string
@@ -50,7 +47,7 @@ func TestCreateTable(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, test.query)
+			err = db.Exec(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return
@@ -71,7 +68,7 @@ func TestCreateTable(t *testing.T) {
 		defer db.Close()
 
 		t.Run("with fixed size data types", func(t *testing.T) {
-			err = db.Exec(ctx, `CREATE TABLE test(d double, b bool)`)
+			err = db.Exec(`CREATE TABLE test(d double, b bool)`)
 			require.NoError(t, err)
 
 			err = db.View(func(tx *genji.Tx) error {
@@ -96,7 +93,7 @@ func TestCreateTable(t *testing.T) {
 		})
 
 		t.Run("with variable size data types", func(t *testing.T) {
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 				CREATE TABLE test1(
 					foo.bar[1].hello bytes PRIMARY KEY, foo.a[1][2] TEXT NOT NULL, bar[4][0].bat integer, b blob, t text, a array, d document
 				)
@@ -129,9 +126,7 @@ func TestCreateTable(t *testing.T) {
 		})
 
 		t.Run("with variable aliases data types", func(t *testing.T) {
-			ctx := context.Background()
-
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 				CREATE TABLE test2(
 					foo.bar[1].hello bytes PRIMARY KEY, foo.a[1][2] VARCHAR(255) NOT NULL, bar[4][0].bat tinyint,
 				 	dp double precision, r real, b bigint, m mediumint, eight int8, ii int2, c character(64)
@@ -188,12 +183,10 @@ func TestCreateIndex(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			ctx := context.Background()
-
-			err = db.Exec(ctx, "CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query)
+			err = db.Exec(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -11,8 +10,6 @@ import (
 )
 
 func TestDeleteStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -32,23 +29,23 @@ func TestDeleteStmt(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test")
+			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b) VALUES ('foo2', 'bar1')")
+			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar1')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (d, b, e) VALUES ('foo3', 'bar2', 'bar3')")
+			err = db.Exec("INSERT INTO test (d, b, e) VALUES ('foo3', 'bar2', 'bar3')")
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query, test.params...)
+			err = db.Exec(test.query, test.params...)
 			if test.fails {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			st, err := db.Query(ctx, "SELECT * FROM test")
+			st, err := db.Query("SELECT * FROM test")
 			require.NoError(t, err)
 			defer st.Close()
 

--- a/sql/query/drop.go
+++ b/sql/query/drop.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"context"
 	"errors"
 
 	"github.com/genjidb/genji/database"
@@ -21,7 +20,7 @@ func (stmt DropTableStmt) IsReadOnly() bool {
 
 // Run runs the DropTable statement in the given transaction.
 // It implements the Statement interface.
-func (stmt DropTableStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt DropTableStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {
@@ -49,7 +48,7 @@ func (stmt DropIndexStmt) IsReadOnly() bool {
 
 // Run runs the DropIndex statement in the given transaction.
 // It implements the Statement interface.
-func (stmt DropIndexStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt DropIndexStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.IndexName == "" {

--- a/sql/query/drop_test.go
+++ b/sql/query/drop_test.go
@@ -1,7 +1,6 @@
 package query_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -15,24 +14,22 @@ func TestDropTable(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	ctx := context.Background()
-
-	err = db.Exec(ctx, "CREATE TABLE test1; CREATE TABLE test2; CREATE TABLE test3")
+	err = db.Exec("CREATE TABLE test1; CREATE TABLE test2; CREATE TABLE test3")
 	require.NoError(t, err)
 
-	err = db.Exec(ctx, "DROP TABLE test1")
+	err = db.Exec("DROP TABLE test1")
 	require.NoError(t, err)
 
-	err = db.Exec(ctx, "DROP TABLE IF EXISTS test1")
+	err = db.Exec("DROP TABLE IF EXISTS test1")
 	require.NoError(t, err)
 
 	// Dropping a table that doesn't exist without "IF EXISTS"
 	// should return an error.
-	err = db.Exec(ctx, "DROP TABLE test1")
+	err = db.Exec("DROP TABLE test1")
 	require.Error(t, err)
 
 	// Assert that only the table `test1` has been dropped.
-	res, err := db.Query(ctx, "SELECT table_name FROM __genji_tables")
+	res, err := db.Query("SELECT table_name FROM __genji_tables")
 	require.NoError(t, err)
 	var tables []string
 	err = res.Iterate(func(d document.Document) error {
@@ -49,7 +46,7 @@ func TestDropTable(t *testing.T) {
 	require.Len(t, tables, 2)
 
 	// Dropping a read-only table should fail.
-	err = db.Exec(ctx, "DROP TABLE __genji_tables")
+	err = db.Exec("DROP TABLE __genji_tables")
 	require.Error(t, err)
 }
 
@@ -58,15 +55,13 @@ func TestDropIndex(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	ctx := context.Background()
-
-	err = db.Exec(ctx, `
+	err = db.Exec(`
 		CREATE TABLE test1(foo text); CREATE INDEX idx_test1_foo ON test1(foo);
 		CREATE TABLE test2(bar text); CREATE INDEX idx_test2_bar ON test2(bar);
 	`)
 	require.NoError(t, err)
 
-	err = db.Exec(ctx, "DROP INDEX idx_test2_bar")
+	err = db.Exec("DROP INDEX idx_test2_bar")
 	require.NoError(t, err)
 
 	// Assert that the good index has been dropped.

--- a/sql/query/expr/comparison.go
+++ b/sql/query/expr/comparison.go
@@ -134,7 +134,7 @@ func (op gtOp) IteratePK(tb *database.Table, v document.Value, pkType document.V
 		return err
 	}
 
-	it := tb.Store.NewIterator(engine.IteratorConfig{})
+	it := tb.Store.Iterator(engine.IteratorOptions{})
 	defer it.Close()
 
 	var buf []byte
@@ -151,6 +151,9 @@ func (op gtOp) IteratePK(tb *database.Table, v document.Value, pkType document.V
 		if err != nil {
 			return err
 		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -197,7 +200,7 @@ func (op gteOp) IteratePK(tb *database.Table, v document.Value, pkType document.
 		return err
 	}
 
-	it := tb.Store.NewIterator(engine.IteratorConfig{})
+	it := tb.Store.Iterator(engine.IteratorOptions{})
 	defer it.Close()
 
 	var buf []byte
@@ -211,6 +214,9 @@ func (op gteOp) IteratePK(tb *database.Table, v document.Value, pkType document.
 		if err != nil {
 			return err
 		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -274,7 +280,7 @@ func (op ltOp) IteratePK(tb *database.Table, v document.Value, pkType document.V
 		return err
 	}
 
-	it := tb.Store.NewIterator(engine.IteratorConfig{})
+	it := tb.Store.Iterator(engine.IteratorOptions{})
 	defer it.Close()
 
 	var buf []byte
@@ -291,6 +297,9 @@ func (op ltOp) IteratePK(tb *database.Table, v document.Value, pkType document.V
 		if err != nil {
 			return err
 		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil
@@ -355,7 +364,7 @@ func (op lteOp) IteratePK(tb *database.Table, v document.Value, pkType document.
 		return err
 	}
 
-	it := tb.Store.NewIterator(engine.IteratorConfig{})
+	it := tb.Store.Iterator(engine.IteratorOptions{})
 	defer it.Close()
 
 	var buf []byte
@@ -372,6 +381,9 @@ func (op lteOp) IteratePK(tb *database.Table, v document.Value, pkType document.
 		if err != nil {
 			return err
 		}
+	}
+	if err := it.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/sql/query/insert.go
+++ b/sql/query/insert.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -24,7 +23,7 @@ func (stmt InsertStmt) IsReadOnly() bool {
 
 // Run the Insert statement in the given transaction.
 // It implements the Statement interface.
-func (stmt InsertStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt InsertStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableName == "" {

--- a/sql/query/reindex.go
+++ b/sql/query/reindex.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"context"
 	"errors"
 	
 	"github.com/genjidb/genji/database"
@@ -20,7 +19,7 @@ func (stmt ReIndexStmt) IsReadOnly() bool {
 
 // Run runs the Reindex statement in the given transaction.
 // It implements the Statement interface.
-func (stmt ReIndexStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt ReIndexStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	var res Result
 
 	if stmt.TableOrIndexName == "" {

--- a/sql/query/reindex_test.go
+++ b/sql/query/reindex_test.go
@@ -1,7 +1,6 @@
 package query_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -10,8 +9,6 @@ import (
 )
 
 func TestReIndex(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name            string
 		query           string
@@ -31,7 +28,7 @@ func TestReIndex(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, `
+			err = db.Exec(`
 				CREATE TABLE test1;
 				CREATE TABLE test2;
 
@@ -45,7 +42,7 @@ func TestReIndex(t *testing.T) {
 			`)
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query)
+			err = db.Exec(test.query)
 			if test.fails {
 				require.Error(t, err)
 				return

--- a/sql/query/select_test.go
+++ b/sql/query/select_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"testing"
 
@@ -12,8 +11,6 @@ import (
 )
 
 func TestSelectStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -97,10 +94,10 @@ func TestSelectStmt(t *testing.T) {
 				require.NoError(t, err)
 				defer db.Close()
 
-				err = db.Exec(ctx, "CREATE TABLE test (k INTEGER PRIMARY KEY)")
+				err = db.Exec("CREATE TABLE test (k INTEGER PRIMARY KEY)")
 				require.NoError(t, err)
 				if withIndexes {
-					err = db.Exec(ctx, `
+					err = db.Exec(`
 						CREATE INDEX idx_color ON test (color);
 						CREATE INDEX idx_size ON test (size);
 						CREATE INDEX idx_shape ON test (shape);
@@ -110,14 +107,14 @@ func TestSelectStmt(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				err = db.Exec(ctx, "INSERT INTO test (k, color, size, shape) VALUES (1, 'red', 10, 'square')")
+				err = db.Exec("INSERT INTO test (k, color, size, shape) VALUES (1, 'red', 10, 'square')")
 				require.NoError(t, err)
-				err = db.Exec(ctx, "INSERT INTO test (k, color, size, weight) VALUES (2, 'blue', 10, 100)")
+				err = db.Exec("INSERT INTO test (k, color, size, weight) VALUES (2, 'blue', 10, 100)")
 				require.NoError(t, err)
-				err = db.Exec(ctx, "INSERT INTO test (k, height, weight) VALUES (3, 100, 200)")
+				err = db.Exec("INSERT INTO test (k, height, weight) VALUES (3, 100, 200)")
 				require.NoError(t, err)
 
-				st, err := db.Query(ctx, test.query, test.params...)
+				st, err := db.Query(test.query, test.params...)
 				defer st.Close()
 				if test.fails {
 					require.Error(t, err)
@@ -140,16 +137,16 @@ func TestSelectStmt(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "CREATE TABLE test (foo INTEGER PRIMARY KEY)")
+		err = db.Exec("CREATE TABLE test (foo INTEGER PRIMARY KEY)")
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (1, 'a')`)
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (2, 'b')`)
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (3, 'c')`)
-		err = db.Exec(ctx, `INSERT INTO test (foo, bar) VALUES (4, 'd')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (1, 'a')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (2, 'b')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (3, 'c')`)
+		err = db.Exec(`INSERT INTO test (foo, bar) VALUES (4, 'd')`)
 		require.NoError(t, err)
 
-		st, err := db.Query(ctx, "SELECT * FROM test WHERE foo < 400 AND foo >= 2")
+		st, err := db.Query("SELECT * FROM test WHERE foo < 400 AND foo >= 2")
 		require.NoError(t, err)
 		defer st.Close()
 
@@ -164,14 +161,14 @@ func TestSelectStmt(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "CREATE TABLE test")
+		err = db.Exec("CREATE TABLE test")
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `INSERT INTO test VALUES {a: {b: 1}}, {a: 1}, {a: [1, 2, [8,9]]}`)
+		err = db.Exec(`INSERT INTO test VALUES {a: {b: 1}}, {a: 1}, {a: [1, 2, [8,9]]}`)
 		require.NoError(t, err)
 
 		call := func(q string, res ...string) {
-			st, err := db.Query(ctx, q)
+			st, err := db.Query(q)
 			require.NoError(t, err)
 			defer st.Close()
 
@@ -197,7 +194,7 @@ func TestSelectStmt(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "SELECT * FROM foo")
+		err = db.Exec("SELECT * FROM foo")
 		require.Error(t, err)
 	})
 
@@ -206,13 +203,13 @@ func TestSelectStmt(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		err = db.Exec(ctx, "CREATE TABLE test; CREATE INDEX idx_foo ON test(foo);")
+		err = db.Exec("CREATE TABLE test; CREATE INDEX idx_foo ON test(foo);")
 		require.NoError(t, err)
 
-		err = db.Exec(ctx, `INSERT INTO test (foo) VALUES (1), ('hello'), (2), (true)`)
+		err = db.Exec(`INSERT INTO test (foo) VALUES (1), ('hello'), (2), (true)`)
 		require.NoError(t, err)
 
-		st, err := db.Query(ctx, "SELECT * FROM test ORDER BY foo")
+		st, err := db.Query("SELECT * FROM test ORDER BY foo")
 		require.NoError(t, err)
 		defer st.Close()
 

--- a/sql/query/transaction.go
+++ b/sql/query/transaction.go
@@ -13,13 +13,13 @@ type BeginStmt struct {
 	Writable bool
 }
 
-func (stmt BeginStmt) alterQuery(db *database.Database, q *Query) error {
+func (stmt BeginStmt) alterQuery(ctx context.Context, db *database.Database, q *Query) error {
 	if q.tx != nil {
 		return errors.New("cannot begin a transaction within a transaction")
 	}
 
 	var err error
-	q.tx, err = db.BeginTx(&database.TxOptions{
+	q.tx, err = db.BeginTx(ctx, &database.TxOptions{
 		ReadOnly: !stmt.Writable,
 		Attached: true,
 	})
@@ -31,14 +31,14 @@ func (stmt BeginStmt) IsReadOnly() bool {
 	return !stmt.Writable
 }
 
-func (stmt BeginStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt BeginStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	return Result{}, errors.New("cannot begin a transaction within a transaction")
 }
 
 // RollbackStmt is a statement that rollbacks the current active transaction.
 type RollbackStmt struct{}
 
-func (stmt RollbackStmt) alterQuery(db *database.Database, q *Query) error {
+func (stmt RollbackStmt) alterQuery(ctx context.Context, db *database.Database, q *Query) error {
 	if q.tx == nil || q.autoCommit == true {
 		return errors.New("cannot rollback with no active transaction")
 	}
@@ -55,14 +55,14 @@ func (stmt RollbackStmt) IsReadOnly() bool {
 	return false
 }
 
-func (stmt RollbackStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt RollbackStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	return Result{}, errors.New("cannot rollback with no active transaction")
 }
 
 // CommitStmt is a statement that commits the current active transaction.
 type CommitStmt struct{}
 
-func (stmt CommitStmt) alterQuery(db *database.Database, q *Query) error {
+func (stmt CommitStmt) alterQuery(ctx context.Context, db *database.Database, q *Query) error {
 	if q.tx == nil || q.autoCommit == true {
 		return errors.New("cannot commit with no active transaction")
 	}
@@ -79,6 +79,6 @@ func (stmt CommitStmt) IsReadOnly() bool {
 	return false
 }
 
-func (stmt CommitStmt) Run(ctx context.Context, tx *database.Transaction, args []expr.Param) (Result, error) {
+func (stmt CommitStmt) Run(tx *database.Transaction, args []expr.Param) (Result, error) {
 	return Result{}, errors.New("cannot commit with no active transaction")
 }

--- a/sql/query/transaction_test.go
+++ b/sql/query/transaction_test.go
@@ -1,7 +1,6 @@
 package query_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -28,15 +27,13 @@ func TestTransactionRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-
 			db, err := genji.Open(":memory:")
 			require.NoError(t, err)
 			defer db.Close()
-			defer db.Exec(ctx, "ROLLBACK")
+			defer db.Exec("ROLLBACK")
 
 			for _, q := range test.queries {
-				err = db.Exec(ctx, q)
+				err = db.Exec(q)
 				if err != nil {
 					break
 				}

--- a/sql/query/update_test.go
+++ b/sql/query/update_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"testing"
 
@@ -12,8 +11,6 @@ import (
 )
 
 func TestUpdateStmt(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name     string
 		query    string
@@ -51,23 +48,23 @@ func TestUpdateStmt(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, "CREATE TABLE test (a text not null)")
+			err = db.Exec("CREATE TABLE test (a text not null)")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
+			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
 			require.NoError(t, err)
-			err = db.Exec(ctx, "INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
+			err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, test.query, test.params...)
+			err = db.Exec(test.query, test.params...)
 			if test.fails {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
-			st, err := db.Query(ctx, "SELECT * FROM test")
+			st, err := db.Query("SELECT * FROM test")
 			require.NoError(t, err)
 			defer st.Close()
 
@@ -103,19 +100,19 @@ func TestUpdateStmt(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close()
 
-			err = db.Exec(ctx, `CREATE TABLE foo;`)
+			err = db.Exec(`CREATE TABLE foo;`)
 			require.NoError(t, err)
-			err = db.Exec(ctx, `INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
+			err = db.Exec(`INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
 			require.NoError(t, err)
 
-			err = db.Exec(ctx, tt.query, tt.params...)
+			err = db.Exec(tt.query, tt.params...)
 			if tt.fails {
 				require.Error(t, err)
 				continue
 			}
 
 			require.NoError(t, err)
-			st, err := db.Query(ctx, "SELECT * FROM foo")
+			st, err := db.Query("SELECT * FROM foo")
 			require.NoError(t, err)
 			defer st.Close()
 


### PR DESCRIPTION
This PR implements API changes for RFC001.

- Context
  - Remove all previous context.Context usage except for (*query.Query).Exec and sql/driver.
  - genji.New, (*database.DB).BeginTx and (engine.Engine).Begin now accept context.Context.
  - Use WithContext pattern in higher-level API.
  - (*database.DB).Begin uses context.Background() so that we don’t have to update a kazillion of transaction test cases.
- Misc
  - (engine.Engine).Begin now accepts a new engine.TxOptions struct.
  - Rename (engine.Store).NewIterator ⇒ (engine.Store).Iterator (see [Effective Go: Getters](https://golang.org/doc/effective_go.html#Getters))
    Rename engine.IteratorConfig ⇒ engine.IteratorOptions for consistency with other option structs.
  - Add new it.Err() checks wherever Go reports compile error from the previous change.

Note that this PR does not add any new cancellation behavior.