### PR TITLE
Fix deadlock with concurrent transactions

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -107,7 +107,9 @@ func (db *Database) Begin(writable bool) (*Transaction, error) {
 // BeginTx starts a new transaction with the given options.
 // If opts is empty, it will use the default options.
 // The returned transaction must be closed either by calling Rollback or Commit.
-// If the Global option is passed, it opens a database level transaction.
+// If the Attached option is passed, it opens a database level transaction, which gets
+// attached to the database and prevents any other transaction to be opened afterwards
+// until it gets rolled back or commited.
 func (db *Database) BeginTx(ctx context.Context, opts *TxOptions) (*Transaction, error) {
 	if opts == nil {
 		opts = new(TxOptions)
@@ -132,6 +134,7 @@ func (db *Database) BeginTx(ctx context.Context, opts *TxOptions) (*Transaction,
 		db:             db,
 		tx:             ntx,
 		writable:       !opts.ReadOnly,
+		attached:       opts.Attached,
 		tableInfoStore: db.tableInfoStore,
 	}
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,69 @@
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/genjidb/genji"
+	"github.com/stretchr/testify/require"
+)
+
+// See issue https://github.com/genjidb/genji/issues/298
+func TestConcurrentTransactionManagement(t *testing.T) {
+	db, err := genji.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ch := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		// 1. Start transaction T1.
+		tx, err := db.Begin(true)
+		require.NoError(t, err)
+
+		// Start transaction T2.
+		ch <- struct{}{}
+		// Wait in case goroutine gets rescheduled.
+		time.Sleep(time.Millisecond)
+
+		// 3. Commit or rollback T1.
+		tx.Rollback()
+
+		// Wait for T2 to finish and return.
+		<-ch
+		done <- struct{}{}
+	}()
+
+	go func() {
+		<-ch // wait for T1 to start.
+
+		// 2. Attempt to start transaction T2.
+		// Waits for T1 to finish.
+		tx, err := db.Begin(true)
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		ch <- struct{}{}
+	}()
+
+	r := make(chan bool)
+	go func() {
+		t := time.NewTimer(time.Second)
+		select {
+		case <-t.C:
+			r <- false
+		case <-done:
+			r <- true
+		}
+		if !t.Stop() {
+			<-t.C
+		}
+	}()
+
+	if ok := <-r; !ok {
+		t.Fatal("deadlock")
+	}
+}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -12,7 +12,9 @@ import (
 func TestConcurrentTransactionManagement(t *testing.T) {
 	db, err := genji.Open(":memory:")
 	require.NoError(t, err)
-	defer db.Close()
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
 
 	ch := make(chan struct{})
 	done := make(chan struct{})
@@ -28,7 +30,7 @@ func TestConcurrentTransactionManagement(t *testing.T) {
 		time.Sleep(time.Millisecond)
 
 		// 3. Commit or rollback T1.
-		tx.Rollback()
+		require.NoError(t, tx.Rollback())
 
 		// Wait for T2 to finish and return.
 		<-ch
@@ -42,7 +44,7 @@ func TestConcurrentTransactionManagement(t *testing.T) {
 		// Waits for T1 to finish.
 		tx, err := db.Begin(true)
 		require.NoError(t, err)
-		defer tx.Rollback()
+		require.NoError(t, tx.Rollback())
 
 		ch <- struct{}{}
 	}()

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -11,9 +11,7 @@ import (
 // See issue https://github.com/genjidb/genji/issues/298
 func TestConcurrentTransactionManagement(t *testing.T) {
 	db, err := genji.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
 	ch := make(chan struct{})


### PR DESCRIPTION
This fixes #298 by making sure access to the `attachedTxMu` mutex is only locked by Commit or Rollback if that transaction is actually attached.
