### PR TITLE
Add .save command

### DIFF
--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -488,6 +488,25 @@ func (sh *Shell) runCommand(ctx context.Context, in string) error {
 		}
 
 		return runDumpCmd(db, cmd[1:], os.Stdout)
+	case ".save":
+		db, err := sh.getDB(ctx)
+		if err != nil {
+			return err
+		}
+
+		var engine, path string
+		if len(cmd) > 2 {
+			engine = cmd[1]
+			path = cmd[2]
+		} else if len(cmd) == 2 {
+			engine = "bolt"
+			path = cmd[1]
+		} else {
+			return fmt.Errorf("Can't save without output path")
+		}
+
+		return runSaveCmd(ctx, db, engine, path)
+
 	default:
 		return displaySuggestions(in)
 	}


### PR DESCRIPTION
Fixes #311; These changes should cover the use case. 

There is one ambiguous part though, what do we do when the target file exists? I went for the least surprising route, just naively write all the K,V pairs over the new database, instead of let's say, removing the files or clearing all K,V pairs before writing the new ones, which could have dire consequences in case of a ctrl-c for example. 

Please tell me if you think I missed something or have any feedback! 