### PR TITLE
Remove in-memory tableInfoStore

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -360,7 +360,7 @@ func (t *tableInfoStore) Delete(tx *Transaction, tableName string) error {
 	return nil
 }
 
-// Replace table information by the new one.
+// Replace replaces tableName table information with the new info.
 func (t *tableInfoStore) Replace(tx *Transaction, tableName string, info *TableInfo) error {
 	var buf bytes.Buffer
 	err := t.db.Codec.NewEncoder(&buf).EncodeDocument(info.ToDocument())

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -194,7 +194,7 @@ func TestTxTable(t *testing.T) {
 
 		// Renaming a non existing table should return an error
 		err = tx.AddField("bar", fieldToAdd)
-		require.EqualError(t, database.ErrTableNotFound, err.Error())
+		require.True(t, errors.Is(err, database.ErrTableNotFound))
 
 		// Adding a existing field should return an error
 		err = tx.AddField("foo", ti.FieldConstraints[0])

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -194,7 +194,9 @@ func TestTxTable(t *testing.T) {
 
 		// Renaming a non existing table should return an error
 		err = tx.AddField("bar", fieldToAdd)
-		require.True(t, errors.Is(err, database.ErrTableNotFound))
+		if !errors.Is(err, database.ErrTableNotFound) {
+			require.Equal(t, err, database.ErrTableNotFound)
+		}
 
 		// Adding a existing field should return an error
 		err = tx.AddField("foo", ti.FieldConstraints[0])


### PR DESCRIPTION
This PR simplifies how we are handling table information. Currently, table information is loaded in memory on database startup. This was done to fix issues with concurrent table creation with the badger engine, but I believe this is not the right solution for that problem.
With this change, table information is not cached anymore and directly fetched from the engine.