### PR TITLE
remove duplicate Reset() of bytes.Buffer

### DIFF
--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -243,7 +243,6 @@ func dumpTable(tx *genji.Tx, tableName string, w io.Writer) error {
 	if _, err = buf.WriteTo(w); err != nil {
 		return err
 	}
-	buf.Reset()
 
 	// Indexes statements.
 	indexes, err := t.Indexes()
@@ -286,8 +285,6 @@ func dumpTable(tx *genji.Tx, tableName string, w io.Writer) error {
 		if _, err = buf.WriteTo(w); err != nil {
 			return err
 		}
-
-		buf.Reset()
 
 		return nil
 	})


### PR DESCRIPTION
This PR removes duplicates `buf.Reset()`.
`byte.Buffer` is already flushed in `buf.WriteTo(w)`.
  [see WriteTo](https://golang.org/src/bytes/buffer.go?s=7711:7769#L255)