### PR TITLE
Soft delete store keys before commit

### DIFF
--- a/engine/badgerengine/store.go
+++ b/engine/badgerengine/store.go
@@ -50,6 +50,10 @@ func (s *Store) Put(k, v []byte) error {
 		return errors.New("cannot store empty key")
 	}
 
+	if len(v) == 0 {
+		return errors.New("cannot store empty value")
+	}
+
 	return s.tx.Set(buildKey(s.prefix, k), v)
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -66,6 +66,7 @@ type Store interface {
 	// Get returns a value associated with the given key. If no key is not found, it returns ErrKeyNotFound.
 	Get(k []byte) ([]byte, error)
 	// Put stores a key value pair. If it already exists, it overrides it.
+	// Both k and v must be not nil.
 	Put(k, v []byte) error
 	// Delete a key value pair. If the key is not found, returns ErrKeyNotFound.
 	Delete(k []byte) error

--- a/engine/enginetest/testing.go
+++ b/engine/enginetest/testing.go
@@ -1006,6 +1006,7 @@ func TestStoreDelete(t *testing.T, builder Builder) {
 
 		// the deleted key must not appear on iteration
 		it := st.Iterator(engine.IteratorOptions{})
+		defer it.Close()
 		i := 0
 		for it.Seek(nil); it.Valid(); it.Next() {
 			require.Equal(t, []byte("foo"), it.Item().Key())

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -294,6 +294,15 @@ func (it *iterator) runIterator(pivot []byte) {
 }
 
 func (it *iterator) Valid() bool {
+	if it.err != nil {
+		return false
+	}
+	select {
+	case <-it.tx.ctx.Done():
+		it.err = it.tx.ctx.Err()
+	default:
+	}
+
 	return it.item != nil && it.err == nil
 }
 

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -57,6 +57,10 @@ func (s *storeTx) Put(k, v []byte) error {
 		return errors.New("empty keys are forbidden")
 	}
 
+	if len(v) == 0 {
+		return errors.New("empty values are forbidden")
+	}
+
 	it := &item{k: k}
 	// if there is an existing value, fetch it
 	// and overwrite it directly using the pointer.


### PR DESCRIPTION
This PR makes the engine store soft delete keys and cleanup on commit. This is done to prevent tree rebalancing when iterating and deleting at the same time, which was a problem with Bolt.
It also prevents inserting empty values in stores.