### PR TITLE
Add ORDER BY, LIMIT and OFFSET clauses to DELETE statement

### DIFF
--- a/sql/parser/delete_test.go
+++ b/sql/parser/delete_test.go
@@ -26,11 +26,24 @@ func TestParserDelete(t *testing.T) {
 				Pipe(stream.Skip(20)).
 				Pipe(stream.TableDelete("test")),
 		},
-		{"WithOffsetThenOrderBy", "DELETE FROM test WHERE age = 10 ORDER BY age OFFSET 20",
+		{"WithLimit", "DELETE FROM test LIMIT 10",
+			stream.New(stream.SeqScan("test")).
+				Pipe(stream.Take(10)).
+				Pipe(stream.TableDelete("test")),
+		},
+		{"WithOrderByThenOffset", "DELETE FROM test WHERE age = 10 ORDER BY age OFFSET 20",
 			stream.New(stream.SeqScan("test")).
 				Pipe(stream.Filter(MustParseExpr("age = 10"))).
 				Pipe(stream.Sort(MustParseExpr("age"))).
 				Pipe(stream.Skip(20)).
+				Pipe(stream.TableDelete("test")),
+		},
+		{"WithOrderByThenLimitThenOffset", "DELETE FROM test WHERE age = 10 ORDER BY age LIMIT 10 OFFSET 20",
+			stream.New(stream.SeqScan("test")).
+				Pipe(stream.Filter(MustParseExpr("age = 10"))).
+				Pipe(stream.Sort(MustParseExpr("age"))).
+				Pipe(stream.Skip(20)).
+				Pipe(stream.Take(10)).
 				Pipe(stream.TableDelete("test")),
 		},
 	}

--- a/sql/parser/delete_test.go
+++ b/sql/parser/delete_test.go
@@ -26,6 +26,13 @@ func TestParserDelete(t *testing.T) {
 				Pipe(stream.Skip(20)).
 				Pipe(stream.TableDelete("test")),
 		},
+		{"WithOffsetThenOrderBy", "DELETE FROM test WHERE age = 10 ORDER BY age OFFSET 20",
+			stream.New(stream.SeqScan("test")).
+				Pipe(stream.Filter(MustParseExpr("age = 10"))).
+				Pipe(stream.Sort(MustParseExpr("age"))).
+				Pipe(stream.Skip(20)).
+				Pipe(stream.TableDelete("test")),
+		},
 	}
 
 	for _, test := range tests {

--- a/sql/parser/delete_test.go
+++ b/sql/parser/delete_test.go
@@ -20,6 +20,12 @@ func TestParserDelete(t *testing.T) {
 				Pipe(stream.Filter(MustParseExpr("age = 10"))).
 				Pipe(stream.TableDelete("test")),
 		},
+		{"WithOffset", "DELETE FROM test WHERE age = 10 OFFSET 20",
+			stream.New(stream.SeqScan("test")).
+				Pipe(stream.Filter(MustParseExpr("age = 10"))).
+				Pipe(stream.Skip(20)).
+				Pipe(stream.TableDelete("test")),
+		},
 	}
 
 	for _, test := range tests {

--- a/sql/parser/order_by.go
+++ b/sql/parser/order_by.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"github.com/genjidb/genji/sql/query/expr"
+	"github.com/genjidb/genji/sql/scanner"
+)
+
+func (p *Parser) parseOrderBy() (expr.Path, scanner.Token, error) {
+	// parse ORDER token
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.ORDER {
+		p.Unscan()
+		return nil, 0, nil
+	}
+
+	// parse BY token
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.BY {
+		return nil, 0, newParseError(scanner.Tokstr(tok, lit), []string{"BY"}, pos)
+	}
+
+	// parse path
+	path, err := p.parsePath()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// parse optional ASC or DESC
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == scanner.ASC || tok == scanner.DESC {
+		return expr.Path(path), tok, nil
+	}
+	p.Unscan()
+
+	return expr.Path(path), 0, nil
+}
+
+func (p *Parser) parseLimit() (expr.Expr, error) {
+	// parse LIMIT token
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LIMIT {
+		p.Unscan()
+		return nil, nil
+	}
+
+	e, _, err := p.ParseExpr()
+	return e, err
+}
+
+func (p *Parser) parseOffset() (expr.Expr, error) {
+	// parse OFFSET token
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.OFFSET {
+		p.Unscan()
+		return nil, nil
+	}
+
+	e, _, err := p.ParseExpr()
+	return e, err
+}

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -173,55 +173,6 @@ func (p *Parser) parseGroupBy() (expr.Expr, error) {
 	return e, err
 }
 
-func (p *Parser) parseOrderBy() (expr.Path, scanner.Token, error) {
-	// parse ORDER token
-	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.ORDER {
-		p.Unscan()
-		return nil, 0, nil
-	}
-
-	// parse BY token
-	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != scanner.BY {
-		return nil, 0, newParseError(scanner.Tokstr(tok, lit), []string{"BY"}, pos)
-	}
-
-	// parse path
-	path, err := p.parsePath()
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// parse optional ASC or DESC
-	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == scanner.ASC || tok == scanner.DESC {
-		return expr.Path(path), tok, nil
-	}
-	p.Unscan()
-
-	return expr.Path(path), 0, nil
-}
-
-func (p *Parser) parseLimit() (expr.Expr, error) {
-	// parse LIMIT token
-	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.LIMIT {
-		p.Unscan()
-		return nil, nil
-	}
-
-	e, _, err := p.ParseExpr()
-	return e, err
-}
-
-func (p *Parser) parseOffset() (expr.Expr, error) {
-	// parse OFFSET token
-	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != scanner.OFFSET {
-		p.Unscan()
-		return nil, nil
-	}
-
-	e, _, err := p.ParseExpr()
-	return e, err
-}
-
 // SelectConfig holds SELECT configuration.
 type selectConfig struct {
 	TableName        string

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -17,13 +17,15 @@ func TestDeleteStmt(t *testing.T) {
 		expected string
 		params   []interface{}
 	}{
-		{"No cond", `DELETE FROM test`, false, "", nil},
-		{"With cond", "DELETE FROM test WHERE b = 'bar1'", false, `{"d": "foo3", "b": "bar2", "e": "bar3", "n": 1}`, nil},
-		{"With offset", "DELETE FROM test OFFSET 1", false, `{"a":"foo1", "b":"bar1", "c":"baz1", "n": 3}`, nil},
-		{"With order by then offset", "DELETE FROM test ORDER BY n OFFSET 1", false, `{"d":"foo3", "b":"bar2", "e":"bar3", "n": 1}`, nil},
-		{"With order DESC by then offset", "DELETE FROM test ORDER BY n DESC OFFSET 1", false, `{"a": "foo1", "b": "bar1", "c": "baz1", "n": 3}`, nil},
-		{"Table not found", "DELETE FROM foo WHERE b = 'bar1'", true, "", nil},
-		{"Read-only table", "DELETE FROM __genji_tables", true, "", nil},
+		{"No cond", `DELETE FROM test`, false, "[]", nil},
+		{"With cond", "DELETE FROM test WHERE b = 'bar1'", false, `[{"d": "foo3", "b": "bar2", "e": "bar3", "n": 1}]`, nil},
+		{"With offset", "DELETE FROM test OFFSET 1", false, `[{"a":"foo1", "b":"bar1", "c":"baz1", "n": 3}]`, nil},
+		{"With order by then offset", "DELETE FROM test ORDER BY n OFFSET 1", false, `[{"d":"foo3", "b":"bar2", "e":"bar3", "n": 1}]`, nil},
+		{"With order by DESC then offset", "DELETE FROM test ORDER BY n DESC OFFSET 1", false, `[{"a": "foo1", "b": "bar1", "c": "baz1", "n": 3}]`, nil},
+		{"With limit", "DELETE FROM test ORDER BY n LIMIT 2", false, `[{"a":"foo1", "b":"bar1", "c":"baz1", "n": 3}]`, nil},
+		{"With order by then limit then offset", "DELETE FROM test ORDER BY n LIMIT 1 OFFSET 1", false, `[{"a": "foo1", "b": "bar1", "c": "baz1", "n": 3}, {"d": "foo3", "b": "bar2", "e": "bar3", "n": 1}]`, nil},
+		{"Table not found", "DELETE FROM foo WHERE b = 'bar1'", true, "[]", nil},
+		{"Read-only table", "DELETE FROM __genji_tables", true, "[]", nil},
 	}
 
 	for _, test := range tests {
@@ -53,13 +55,9 @@ func TestDeleteStmt(t *testing.T) {
 			defer st.Close()
 
 			var buf bytes.Buffer
-			err = document.IteratorToJSON(&buf, st)
+			err = document.IteratorToJSONArray(&buf, st)
 			require.NoError(t, err)
-			if len(test.expected) == 0 {
-				require.Equal(t, 0, buf.Len())
-			} else {
-				require.JSONEq(t, test.expected, buf.String())
-			}
+			require.JSONEq(t, test.expected, buf.String())
 		})
 	}
 }

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -18,8 +18,10 @@ func TestDeleteStmt(t *testing.T) {
 		params   []interface{}
 	}{
 		{"No cond", `DELETE FROM test`, false, "", nil},
-		{"With cond", "DELETE FROM test WHERE b = 'bar1'", false, `{"d": "foo3", "b": "bar2", "e": "bar3"}`, nil},
-		{"With offset", "DELETE FROM test OFFSET 1", false, `{"a":"foo1", "b":"bar1", "c":"baz1"}`, nil},
+		{"With cond", "DELETE FROM test WHERE b = 'bar1'", false, `{"d": "foo3", "b": "bar2", "e": "bar3", "n": 1}`, nil},
+		{"With offset", "DELETE FROM test OFFSET 1", false, `{"a":"foo1", "b":"bar1", "c":"baz1", "n": 3}`, nil},
+		{"With order by then offset", "DELETE FROM test ORDER BY n OFFSET 1", false, `{"d":"foo3", "b":"bar2", "e":"bar3", "n": 1}`, nil},
+		{"With order DESC by then offset", "DELETE FROM test ORDER BY n DESC OFFSET 1", false, `{"a": "foo1", "b": "bar1", "c": "baz1", "n": 3}`, nil},
 		{"Table not found", "DELETE FROM foo WHERE b = 'bar1'", true, "", nil},
 		{"Read-only table", "DELETE FROM __genji_tables", true, "", nil},
 	}
@@ -32,11 +34,11 @@ func TestDeleteStmt(t *testing.T) {
 
 			err = db.Exec("CREATE TABLE test")
 			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+			err = db.Exec("INSERT INTO test (a, b, c, n) VALUES ('foo1', 'bar1', 'baz1', 3)")
 			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar1')")
+			err = db.Exec("INSERT INTO test (a, b, n) VALUES ('foo2', 'bar1', 2)")
 			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (d, b, e) VALUES ('foo3', 'bar2', 'bar3')")
+			err = db.Exec("INSERT INTO test (d, b, e, n) VALUES ('foo3', 'bar2', 'bar3', 1)")
 			require.NoError(t, err)
 
 			err = db.Exec(test.query, test.params...)

--- a/sql/query/delete_test.go
+++ b/sql/query/delete_test.go
@@ -19,6 +19,7 @@ func TestDeleteStmt(t *testing.T) {
 	}{
 		{"No cond", `DELETE FROM test`, false, "", nil},
 		{"With cond", "DELETE FROM test WHERE b = 'bar1'", false, `{"d": "foo3", "b": "bar2", "e": "bar3"}`, nil},
+		{"With offset", "DELETE FROM test OFFSET 1", false, `{"a":"foo1", "b":"bar1", "c":"baz1"}`, nil},
 		{"Table not found", "DELETE FROM foo WHERE b = 'bar1'", true, "", nil},
 		{"Read-only table", "DELETE FROM __genji_tables", true, "", nil},
 	}

--- a/sql/query/expr/env.go
+++ b/sql/query/expr/env.go
@@ -112,8 +112,9 @@ func (e *Environment) GetTx() *database.Transaction {
 func (e *Environment) Clone() (*Environment, error) {
 	newEnv := Environment{
 		Params: e.Params,
-		Vars:   document.NewFieldBuffer(),
 	}
+
+	newEnv.Tx = e.Tx
 
 	if e.Doc != nil {
 		fb := document.NewFieldBuffer()
@@ -127,7 +128,7 @@ func (e *Environment) Clone() (*Environment, error) {
 
 	if e.Vars != nil {
 		fb := document.NewFieldBuffer()
-		err := fb.Copy(e.Doc)
+		err := fb.Copy(e.Vars)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/query/expr/env_test.go
+++ b/sql/query/expr/env_test.go
@@ -1,0 +1,38 @@
+package expr_test
+
+import (
+	"testing"
+
+	"github.com/genjidb/genji/database"
+	"github.com/genjidb/genji/document"
+	"github.com/genjidb/genji/sql/query/expr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentClone(t *testing.T) {
+	d := document.NewFieldBuffer()
+	d.Add("answer", document.NewIntegerValue(42))
+
+	p := expr.Param{Name: "param", Value: 1}
+	tx := &database.Transaction{}
+
+	vars := document.NewFieldBuffer()
+	vars.Add("var", document.NewIntegerValue(2))
+
+	env := expr.NewEnvironment(d, p)
+	outer := expr.NewEnvironment(nil)
+
+	env.Tx = tx
+	env.Outer = outer
+	env.Vars = vars
+
+	newEnv, err := env.Clone()
+	require.NoError(t, err)
+
+	require.Equal(t, d, newEnv.Doc)
+	require.Equal(t, 1, len(newEnv.Params))
+	require.Equal(t, p, newEnv.Params[0])
+	require.Equal(t, tx, newEnv.Tx)
+	require.Equal(t, vars, newEnv.Vars)
+	require.Equal(t, outer, newEnv.Outer)
+}


### PR DESCRIPTION
Hey there!

This PR fixes #318, #319 and #320. I grouped my changes to avoid having to open cascading PRs, as those clauses are dependent on each other to be properly tested (the sort operation from the order by must be done before the skip and take ones). 

I found two bugs along the way in `tx.Clone()` and added some tests for them:
- the `Tx` wasn't copied over, which broke getting the table name after sorting the stream 
- the `Vars` weren't copied properly as well 

Finally, the parsing functions for the clauses were now not just being used by the select statement, so they've been extracted in their own file. 

Please tell me if there is anything that must be fixed, changed or done in a different PR, I'll make the changes!

```
genji> EXPLAIN DELETE FROM foo ORDER BY a DESC;
{
  "plan": "seqScan(foo) | sortReverse(a) | tableDelete('foo')"
}
```

```
genji> EXPLAIN DELETE FROM foo LIMIT 1 + 1;
{
  "plan": "seqScan(foo) | take(2) | tableDelete('foo')"
}
```

```
genji> EXPLAIN DELETE FROM foo OFFSET 1 + 1;
{
  "plan": "seqScan(foo) | skip(2) | tableDelete('foo')"
}
```

```
genji> EXPLAIN DELETE FROM foo ORDER BY a LIMIT 5 OFFSET 1 + 1;
{
  "plan": "seqScan(foo) | sort(a) | skip(2) | take(5) | tableDelete('foo')"
}
```