### PR TITLE
Encode and decode compacted ints

### DIFF
--- a/document/encoding/msgpack/codec.go
+++ b/document/encoding/msgpack/codec.go
@@ -124,7 +124,7 @@ func (e *Encoder) EncodeValue(v document.Value) error {
 	case document.BoolValue:
 		return e.enc.EncodeBool(v.V.(bool))
 	case document.IntegerValue:
-		return e.enc.EncodeInt64(v.V.(int64))
+		return e.enc.EncodeInt(v.V.(int64))
 	case document.DoubleValue:
 		return e.enc.EncodeFloat64(v.V.(float64))
 	}
@@ -192,6 +192,18 @@ func (d *Decoder) DecodeValue() (v document.Value, err error) {
 			return
 		}
 		v = document.NewTextValue(s)
+		return
+	}
+
+	// decode fixnum (the msgpack size optimization to encode low value integers)
+	// https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family
+	if msgpcode.IsFixedNum(c) {
+		v.V, err = d.dec.DecodeInt64()
+		if err != nil {
+			return
+		}
+
+		v.Type = document.IntegerValue
 		return
 	}
 

--- a/document/encoding/msgpack/encoding_test.go
+++ b/document/encoding/msgpack/encoding_test.go
@@ -1,16 +1,43 @@
 package msgpack
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/document/encoding"
 	"github.com/genjidb/genji/document/encoding/encodingtest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCodec(t *testing.T) {
 	encodingtest.TestCodec(t, func() encoding.Codec {
 		return NewCodec()
 	})
+}
+
+// The codec decoder has a specific branch to handle the case where low value integers are encoded
+// on a single byte by msgpack, with 7bit for positive uint8 and 5bit for negative int8.
+func TestCompactedIntDecoding(t *testing.T) {
+	d := document.NewFieldBuffer().
+		Add("small-pos-int", document.NewIntegerValue(127)).
+		Add("smaller-pos-int", document.NewIntegerValue(2)).
+		Add("small-neg-int", document.NewIntegerValue(-2)).
+		Add("smaller-neg-int", document.NewIntegerValue(-32)).
+		Add("normal-pos-int", document.NewIntegerValue(2048)).
+		Add("normal-neg-int", document.NewIntegerValue(-2048))
+
+	expected := `{"small-pos-int": 127, "smaller-pos-int": 2, "small-neg-int": -2, "smaller-neg-int": -32, "normal-pos-int": 2048, "normal-neg-int": -2048}`
+
+	codec := NewCodec()
+	var buf bytes.Buffer
+
+	err := codec.NewEncoder(&buf).EncodeDocument(d)
+	require.NoError(t, err)
+
+	data, err := document.MarshalJSON(codec.NewDocument(buf.Bytes()))
+	require.NoError(t, err)
+	require.JSONEq(t, expected, string(data))
 }
 
 func BenchmarkCodec(b *testing.B) {


### PR DESCRIPTION
Hello! 

Here is the fix for #349. 

If we take the output from script used in the above issue: 

_before the PR_: 

```
[129 161 97 211 0 0 0 0 0 0 0 2]
map[%!$(string=a):%!$(int64=2)]v
```

_after the PR_: 
```
[129 161 97 2]
map[%!$(string=a):%!$(int8=2)]v
```

<details><summary>Benchmark outputs</summary>
<p>
_before the PR_: 

```
~/code/src/github.com/genjidb/genji U main› go test -v -run=^\$ -benchmem -bench=. ./document/encoding/msgpack
goos: darwin
goarch: amd64
pkg: github.com/genjidb/genji/document/encoding/msgpack
BenchmarkCodec
BenchmarkCodec/Codec/Encode
BenchmarkCodec/Codec/Encode-12            227773              5279 ns/op            4601 B/op          9 allocs/op
BenchmarkCodec/Codec/Decode
BenchmarkCodec/Codec/Decode-12             84496             14296 ns/op           11552 B/op        112 allocs/op
BenchmarkCodec/Codec/Document/GetByField
BenchmarkCodec/Codec/Document/GetByField-12               163861              8597 ns/op             120 B/op          4 allocs/op
BenchmarkCodec/Codec/Document/Iterate
BenchmarkCodec/Codec/Document/Iterate-12                  113142             10565 ns/op             856 B/op        102 allocs/op
BenchmarkCodec/ComparedWithJSON/Encode
BenchmarkCodec/ComparedWithJSON/Encode-12                  36498             32482 ns/op           10820 B/op        207 allocs/op
BenchmarkCodec/ComparedWithJSON/Decode
BenchmarkCodec/ComparedWithJSON/Decode-12                  24601             47912 ns/op            7304 B/op        492 allocs/op
PASS
ok      github.com/genjidb/genji/document/encoding/msgpack      9.753s

```

_after the PR_: 
```
~/code/src/github.com/genjidb/genji U fix-msgpack-integers-size› go test -v -run=^\$ -benchmem -bench=. ./document/encoding/msgpack
goos: darwin
goarch: amd64
pkg: github.com/genjidb/genji/document/encoding/msgpack
BenchmarkCodec
BenchmarkCodec/Codec/Encode
BenchmarkCodec/Codec/Encode-12            250432              4116 ns/op            2296 B/op          8 allocs/op
BenchmarkCodec/Codec/Decode
BenchmarkCodec/Codec/Decode-12            107022             10898 ns/op           11551 B/op        112 allocs/op
BenchmarkCodec/Codec/Document/GetByField
BenchmarkCodec/Codec/Document/GetByField-12               239082              5339 ns/op             120 B/op          4 allocs/op
BenchmarkCodec/Codec/Document/Iterate
BenchmarkCodec/Codec/Document/Iterate-12                  162720              7553 ns/op             856 B/op        102 allocs/op
BenchmarkCodec/ComparedWithJSON/Encode
BenchmarkCodec/ComparedWithJSON/Encode-12                  37035             32070 ns/op           10820 B/op        207 allocs/op
BenchmarkCodec/ComparedWithJSON/Decode
BenchmarkCodec/ComparedWithJSON/Decode-12                  24105             49398 ns/op            7304 B/op        492 allocs/op
PASS
ok      github.com/genjidb/genji/document/encoding/msgpack      9.361s
```
</p></details>

While not a breaking change at the API layer, it will make the databases that have been created with Genji after this patch unreadable for previous versions of Genji (⚠️). 

See the snippet below to see what the crash looks like. 

<details><summary>Using a db that used the updated codec from a previous genji</summary>
<p>

```
~/code/src/github.com/genjidb/genji/cmd/genji U fix-msgpack-integers-size› go run main.go insert.go -- /tmp/foo.db
On-disk database using BoltDB engine at path /tmp/foo.db.
Enter ".help" for usage hints.
genji> create table foo;
genji> insert info foo (a,b) values (-2, 3);
found info, expected INTO at line 1, char 8
genji> insert into foo (a, b) values (-2, 3);
genji> select * from foo;
{
  "a": -2,
  "b": 3
}
genji> create table bar ( a INTEGER );
genji> insert into bar (a) values (-3);
genji> select * from bar;
{
  "a": -3
}
genji>^D
~/code/src/github.com/genjidb/genji/cmd/genji U fix-msgpack-integers-size› git checkout main                      
M       cmd/genji/go.sum
M       go.mod
M       go.sum
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
~/code/src/github.com/genjidb/genji/cmd/genji U main› go run main.go insert.go -- /tmp/foo.db
On-disk database using BoltDB engine at path /tmp/foo.db.
Enter ".help" for usage hints.
genji> select * from bar;
panic: unsupported type 253 [recovered]
        panic: unsupported type 253

goroutine 20 [running]:
encoding/json.(*encodeState).marshal.func1(0xc00034da18)
        /Users/tech/.asdf/installs/golang/1.15.8/go/src/encoding/json/encode.go:326 +0x85
panic(0x45985c0, 0xc000300490)
        /Users/tech/.asdf/installs/golang/1.15.8/go/src/runtime/panic.go:969 +0x1b9
github.com/genjidb/genji/document/encoding/msgpack.(*Decoder).DecodeValue(0xc0001b6220, 0x4987cc8, 0x1, 0x0, 0x0, 0xc000208000)
        /Users/tech/code/src/github.com/genjidb/genji/document/encoding/msgpack/codec.go:237 +0x825
github.com/genjidb/genji/document/encoding/msgpack.EncodedDocument.Iterate(0xc000316780, 0x4, 0x8, 0xc00030b0c0, 0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/document/encoding/msgpack/encoding.go:127 +0x154
github.com/genjidb/genji/database.(*lazilyDecodedDocument).Iterate(0xc000333100, 0xc00030b0c0, 0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/database/table.go:335 +0x82
github.com/genjidb/genji/document.jsonDocument.MarshalJSON(0x46db8c0, 0xc000333100, 0x400fec5, 0x45c2040, 0x45faac0, 0x49b7701, 0xc216968)
        /Users/tech/code/src/github.com/genjidb/genji/document/document.go:574 +0xba
github.com/genjidb/genji/document.MarshalJSON(...)
        /Users/tech/code/src/github.com/genjidb/genji/document/document.go:30
github.com/genjidb/genji/database.(*lazilyDecodedDocument).MarshalJSON(0xc000333100, 0x45faac0, 0xc000333100, 0xc216968, 0xc000333100, 0xc000333101)
        /Users/tech/code/src/github.com/genjidb/genji/database/table.go:365 +0x37
encoding/json.marshalerEncoder(0xc000312580, 0x45faac0, 0xc000333100, 0x16, 0x4620000)
        /Users/tech/.asdf/installs/golang/1.15.8/go/src/encoding/json/encode.go:477 +0xad
encoding/json.(*encodeState).reflectValue(0xc000312580, 0x45faac0, 0xc000333100, 0x16, 0xc000340000)
        /Users/tech/.asdf/installs/golang/1.15.8/go/src/encoding/json/encode.go:358 +0x82
encoding/json.(*encodeState).marshal(0xc000312580, 0x45faac0, 0xc000333100, 0x0, 0x0, 0x0)
        /Users/tech/.asdf/installs/golang/1.15.8/go/src/encoding/json/encode.go:330 +0xf4
encoding/json.(*Encoder).Encode(0xc00031c4b0, 0x45faac0, 0xc000333100, 0xc00030b060, 0x0)
        /Users/tech/.asdf/installs/golang/1.15.8/go/src/encoding/json/stream.go:206 +0x8b
github.com/genjidb/genji/cmd/genji/shell.(*Shell).runQuery.func1(0x46db8c0, 0xc000333100, 0xc00031b531, 0x4)
        /Users/tech/code/src/github.com/genjidb/genji/cmd/genji/shell/shell.go:538 +0x7b
github.com/genjidb/genji/sql/planner.(*statementIterator).Iterate.func1(0xc000333080, 0xc000333000, 0x49e81d8)
        /Users/tech/code/src/github.com/genjidb/genji/sql/planner/statement.go:63 +0x42
github.com/genjidb/genji/stream.(*SeqScanOperator).Iterate.func1(0x46db8c0, 0xc000333100, 0xc0001b26d0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/stream/iterator.go:139 +0x4a
github.com/genjidb/genji/database.(*Table).iterate(0xc00030d470, 0x0, 0x0, 0x0, 0x0, 0xc00030af20, 0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/database/table.go:485 +0x2a7
github.com/genjidb/genji/database.(*Table).AscendGreaterOrEqual(...)
        /Users/tech/code/src/github.com/genjidb/genji/database/table.go:440
github.com/genjidb/genji/stream.(*SeqScanOperator).Iterate(0xc000332c40, 0xc000332f80, 0xc0003003b0, 0xc0003002b0, 0x1)
        /Users/tech/code/src/github.com/genjidb/genji/stream/iterator.go:137 +0x137
github.com/genjidb/genji/stream.(*Stream).Iterate(...)
        /Users/tech/code/src/github.com/genjidb/genji/stream/stream.go:34
github.com/genjidb/genji/sql/planner.(*statementIterator).Iterate(0xc00030d200, 0xc00030adc0, 0x12, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/sql/planner/statement.go:55 +0x14d
github.com/genjidb/genji/sql/query.(*Result).Iterate(...)
        /Users/tech/code/src/github.com/genjidb/genji/sql/query/query.go:160
github.com/genjidb/genji/cmd/genji/shell.(*Shell).runQuery(0xc00015a360, 0x46e0840, 0xc000332c00, 0xc0002420e0, 0x12, 0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/cmd/genji/shell/shell.go:531 +0x1fe
github.com/genjidb/genji/cmd/genji/shell.(*Shell).executeInput(0xc00015a360, 0x46e0840, 0xc000332c00, 0xc0002420e0, 0x12, 0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/cmd/genji/shell/shell.go:441 +0x2a5
github.com/genjidb/genji/cmd/genji/shell.(*Shell).runExecutor(0xc00015a360, 0x46e0840, 0xc000150900, 0xc00010e240, 0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/cmd/genji/shell/shell.go:221 +0x1cd
github.com/genjidb/genji/cmd/genji/shell.Run.func4(0x0, 0x0)
        /Users/tech/code/src/github.com/genjidb/genji/cmd/genji/shell/shell.go:164 +0x45
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc00011bb00, 0xc00011bb30)
        /Users/tech/code/pkg/mod/golang.org/x/sync@v0.0.0-20201207232520-09787c993a3a/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
        /Users/tech/code/pkg/mod/golang.org/x/sync@v0.0.0-20201207232520-09787c993a3a/errgroup/errgroup.go:54 +0x66
exit status 2
```
</p></details>