### PR TITLE
Use PkScan operator

### DIFF
--- a/database/index.go
+++ b/database/index.go
@@ -200,7 +200,7 @@ func (idx *Index) Truncate() error {
 // EncodeValue encodes the value we are going to use as a key,
 // If the index is typed, encode the value without expecting
 // the presence of other types.
-// Ff not, encode so that order is preserved regardless of the type.
+// If not, encode so that order is preserved regardless of the type.
 func (idx *Index) EncodeValue(v document.Value) ([]byte, error) {
 	if idx.Info.Type != 0 {
 		return v.MarshalBinary()

--- a/db_test.go
+++ b/db_test.go
@@ -163,3 +163,26 @@ func BenchmarkSelectWhere(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkSelectPk(b *testing.B) {
+	for size := 1; size <= 10000; size *= 10 {
+		b.Run(fmt.Sprintf("%.05d", size), func(b *testing.B) {
+			db, err := genji.Open(":memory:")
+			require.NoError(b, err)
+
+			err = db.Exec("CREATE TABLE foo(a INT PRIMARY KEY)")
+			require.NoError(b, err)
+
+			for i := 0; i < size; i++ {
+				err = db.Exec("INSERT INTO foo(a) VALUES (?)", i)
+				require.NoError(b, err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				res, _ := db.Query("SELECT * FROM foo WHERE a = ?", size-1)
+				res.Iterate(func(d document.Document) error { return nil })
+			}
+		})
+	}
+}

--- a/planner/explain.go
+++ b/planner/explain.go
@@ -23,7 +23,7 @@ type ExplainStmt struct {
 func (s *ExplainStmt) Run(tx *database.Transaction, params []expr.Param) (query.Result, error) {
 	switch t := s.Statement.(type) {
 	case *Statement:
-		s, err := Optimize(t.Stream, tx)
+		s, err := Optimize(t.Stream, tx, params)
 		if err != nil {
 			return query.Result{}, err
 		}

--- a/planner/optimizer.go
+++ b/planner/optimizer.go
@@ -499,7 +499,7 @@ func getCandidateFromfilterNode(f *stream.FilterOperator, tableName string, info
 	// we'll start with checking if the path is the primary key of the table
 	if pk := info.GetPrimaryKey(); pk != nil && pk.Path.IsEqual(path) {
 		cd.isPk = true
-		cd.priority = 2
+		cd.priority = 3
 
 		ranges, err := getRangesFromOp(op, e)
 		if err != nil {
@@ -514,7 +514,11 @@ func getCandidateFromfilterNode(f *stream.FilterOperator, tableName string, info
 	// if not, check if an index exists for that path
 	if idx := indexes.GetIndexByPath(document.Path(path)); idx != nil {
 		cd.isIndex = true
-		cd.priority = 1
+		if idx.Info.Unique {
+			cd.priority = 2
+		} else {
+			cd.priority = 1
+		}
 
 		ranges, err := getRangesFromOp(op, e)
 		if err != nil {

--- a/planner/optimizer.go
+++ b/planner/optimizer.go
@@ -389,7 +389,7 @@ func isProjectionUnique(indexes database.Indexes, po *stream.ProjectOperator, pk
 // - one of its operands is a path expression that is indexed
 // - the other operand is a literal value or a parameter
 // If found, it will replace the input node by an indexInputNode using this index.
-// TODO(asdine): add support for ORDER BY and primary keys
+// TODO(asdine): add support for ORDER BY
 func UseIndexBasedOnFilterNodeRule(s *stream.Stream, tx *database.Transaction, params []expr.Param) (*stream.Stream, error) {
 	n := s.Op
 

--- a/planner/optimizer.go
+++ b/planner/optimizer.go
@@ -526,6 +526,11 @@ func getCandidateFromfilterNode(f *stream.FilterOperator, tableName string, info
 
 	// we'll start with checking if the path is the primary key of the table
 	if pk := info.GetPrimaryKey(); pk != nil && pk.Path.IsEqual(path) {
+		// if both types are different, don't select this scanner
+		if pk.Type != v.Type {
+			return nil, nil
+		}
+
 		cd.isPk = true
 		cd.priority = 3
 
@@ -541,6 +546,11 @@ func getCandidateFromfilterNode(f *stream.FilterOperator, tableName string, info
 
 	// if not, check if an index exists for that path
 	if idx := indexes.GetIndexByPath(document.Path(path)); idx != nil {
+		// if both types are different, don't select this scanner
+		if !idx.Info.Type.IsZero() && idx.Info.Type != v.Type {
+			return nil, nil
+		}
+
 		cd.isIndex = true
 		if idx.Info.Unique {
 			cd.priority = 2

--- a/planner/statement.go
+++ b/planner/statement.go
@@ -17,7 +17,7 @@ type Statement struct {
 // Run returns a result containing the stream. The stream will be executed by calling the Iterate method of
 // the result.
 func (s *Statement) Run(tx *database.Transaction, params []expr.Param) (query.Result, error) {
-	st, err := Optimize(s.Stream, tx)
+	st, err := Optimize(s.Stream, tx, params)
 	if err != nil || st == nil {
 		return query.Result{}, err
 	}

--- a/stream/iterator_test.go
+++ b/stream/iterator_test.go
@@ -140,7 +140,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			stream.Ranges{
-				{Max: parser.MustParseExpr("2")},
+				{Max: document.NewIntegerValue(2)},
 			},
 			false, false,
 		},
@@ -149,7 +149,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`),
 			stream.Ranges{
-				{Max: parser.MustParseExpr("1")},
+				{Max: document.NewIntegerValue(1)},
 			},
 			false, false,
 		},
@@ -158,7 +158,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1")},
+				{Min: document.NewIntegerValue(1)},
 			},
 			false, false,
 		},
@@ -167,7 +167,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2")},
+				{Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2)},
 			},
 			false, false,
 		},
@@ -182,7 +182,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 2}`, `{"a": 1}`),
 			stream.Ranges{
-				{Max: parser.MustParseExpr("2")},
+				{Max: document.NewIntegerValue(2)},
 			},
 			true, false,
 		},
@@ -191,7 +191,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 2}`, `{"a": 1}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1")},
+				{Min: document.NewIntegerValue(1)},
 			},
 			true, false,
 		},
@@ -200,7 +200,7 @@ func TestPkScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 2}`, `{"a": 1}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2")},
+				{Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2)},
 			},
 			true, false,
 		},
@@ -259,13 +259,13 @@ func TestPkScan(t *testing.T) {
 
 	t.Run("String", func(t *testing.T) {
 		require.Equal(t, `pkScan("test", [1, 2])`, stream.PkScan("test", stream.Range{
-			Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2"),
+			Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2),
 		}).String())
 
 		op := stream.PkScan("test",
-			stream.Range{Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2"), Exclusive: true},
-			stream.Range{Min: parser.MustParseExpr("10"), Exact: true},
-			stream.Range{Min: parser.MustParseExpr("100")},
+			stream.Range{Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2), Exclusive: true},
+			stream.Range{Min: document.NewIntegerValue(10), Exact: true},
+			stream.Range{Min: document.NewIntegerValue(100)},
 		)
 		op.Reverse = true
 
@@ -293,7 +293,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			stream.Ranges{
-				{Max: parser.MustParseExpr("2")},
+				{Max: document.NewIntegerValue(2)},
 			},
 			false, false,
 		},
@@ -302,7 +302,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`),
 			stream.Ranges{
-				{Max: parser.MustParseExpr("1")},
+				{Max: document.NewIntegerValue(1)},
 			},
 			false, false,
 		},
@@ -311,7 +311,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1")},
+				{Min: document.NewIntegerValue(1)},
 			},
 			false, false,
 		},
@@ -320,7 +320,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2")},
+				{Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2)},
 			},
 			false, false,
 		},
@@ -335,7 +335,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 2}`, `{"a": 1}`),
 			stream.Ranges{
-				{Max: parser.MustParseExpr("2")},
+				{Max: document.NewIntegerValue(2)},
 			},
 			true, false,
 		},
@@ -344,7 +344,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 2}`, `{"a": 1}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1")},
+				{Min: document.NewIntegerValue(1)},
 			},
 			true, false,
 		},
@@ -353,7 +353,7 @@ func TestIndexScan(t *testing.T) {
 			testutil.MakeDocuments(t, `{"a": 1}`, `{"a": 2}`),
 			testutil.MakeDocuments(t, `{"a": 2}`, `{"a": 1}`),
 			stream.Ranges{
-				{Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2")},
+				{Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2)},
 			},
 			true, false,
 		},
@@ -412,11 +412,11 @@ func TestIndexScan(t *testing.T) {
 
 	t.Run("String", func(t *testing.T) {
 		require.Equal(t, `indexScan("idx_test_a", [1, 2])`, stream.IndexScan("idx_test_a", stream.Range{
-			Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2"),
+			Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2),
 		}).String())
 
 		op := stream.IndexScan("idx_test_a", stream.Range{
-			Min: parser.MustParseExpr("1"), Max: parser.MustParseExpr("2"),
+			Min: document.NewIntegerValue(1), Max: document.NewIntegerValue(2),
 		})
 		op.Reverse = true
 


### PR DESCRIPTION
This PR modifies the planner to use the stream.PkScan operator when possible.
This operator behaves like an index but is faster and space efficient because it uses
the table tree rather than a separate index tree.

Benchmarks:

Before

```bash
$ go test -count=5 -benchmem -run=^$ -bench BenchmarkSelectPk | tee old.txt
goos: linux
goarch: amd64
pkg: github.com/genjidb/genji
cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
BenchmarkSelectPk/00001-12                 60174             17452 ns/op            4184 B/op         90 allocs/op
BenchmarkSelectPk/00001-12                 67738             17082 ns/op            4183 B/op         90 allocs/op
BenchmarkSelectPk/00001-12                 71444             16640 ns/op            4183 B/op         90 allocs/op
BenchmarkSelectPk/00001-12                 69579             17069 ns/op            4183 B/op         90 allocs/op
BenchmarkSelectPk/00001-12                 67123             16799 ns/op            4183 B/op         90 allocs/op
BenchmarkSelectPk/00010-12                 63070             18711 ns/op            5224 B/op        135 allocs/op
BenchmarkSelectPk/00010-12                 62373             19149 ns/op            5224 B/op        135 allocs/op
BenchmarkSelectPk/00010-12                 61804             18993 ns/op            5223 B/op        135 allocs/op
BenchmarkSelectPk/00010-12                 61906             19465 ns/op            5226 B/op        135 allocs/op
BenchmarkSelectPk/00010-12                 61243             18744 ns/op            5225 B/op        135 allocs/op
BenchmarkSelectPk/00100-12                 12324             96532 ns/op           15691 B/op        585 allocs/op
BenchmarkSelectPk/00100-12                 12452             95986 ns/op           15687 B/op        585 allocs/op
BenchmarkSelectPk/00100-12                 12182             97492 ns/op           15686 B/op        585 allocs/op
BenchmarkSelectPk/00100-12                 12422             96658 ns/op           15689 B/op        585 allocs/op
BenchmarkSelectPk/00100-12                 12366             98609 ns/op           15685 B/op        585 allocs/op
BenchmarkSelectPk/01000-12                  1333            880389 ns/op          138400 B/op       6830 allocs/op
BenchmarkSelectPk/01000-12                  1354            908564 ns/op          138278 B/op       6830 allocs/op
BenchmarkSelectPk/01000-12                  1345            879852 ns/op          138388 B/op       6830 allocs/op
BenchmarkSelectPk/01000-12                  1336            890207 ns/op          138356 B/op       6830 allocs/op
BenchmarkSelectPk/01000-12                  1342            882389 ns/op          138293 B/op       6830 allocs/op
BenchmarkSelectPk/10000-12                   132           9377784 ns/op         1371696 B/op      69839 allocs/op
BenchmarkSelectPk/10000-12                   129           9044030 ns/op         1370267 B/op      69838 allocs/op
BenchmarkSelectPk/10000-12                   132           9024456 ns/op         1371280 B/op      69839 allocs/op
BenchmarkSelectPk/10000-12                   127           9021765 ns/op         1370703 B/op      69838 allocs/op
BenchmarkSelectPk/10000-12                   132           9436749 ns/op         1370667 B/op      69838 allocs/op
```

After

```bash
$ go test -count=5 -benchmem -run=^$ -bench BenchmarkSelectPk | tee new.txt
goos: linux
goarch: amd64
pkg: github.com/genjidb/genji
cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
BenchmarkSelectPk/00001-12                 59692             18439 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00001-12                 67766             17365 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00001-12                 68274             17324 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00001-12                 68650             17540 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00001-12                 67000             17293 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00010-12                 68598             17529 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00010-12                 65353             17302 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00010-12                 69853             17606 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00010-12                 67478             17089 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00010-12                 62709             17468 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00100-12                 53097             22570 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00100-12                 55345             22118 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00100-12                 54732             22356 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00100-12                 54140             21778 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/00100-12                 53340             22305 ns/op            4632 B/op         95 allocs/op
BenchmarkSelectPk/01000-12                 54985             22117 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/01000-12                 54417             21713 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/01000-12                 55604             22208 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/01000-12                 54969             21824 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/01000-12                 54782             22163 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/10000-12                 54614             22786 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/10000-12                 56102             21710 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/10000-12                 54963             21659 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/10000-12                 55752             21549 ns/op            4648 B/op         97 allocs/op
BenchmarkSelectPk/10000-12                 55063             21579 ns/op            4648 B/op         97 allocs/op
```

Benchstat:

```bash
$ benchstat old.txt new.txt
name               old time/op    new time/op    delta
SelectPk/00001-12    17.0µs ± 3%    17.6µs ± 5%     ~     (p=0.056 n=5+5)
SelectPk/00010-12    19.0µs ± 2%    17.4µs ± 2%   -8.49%  (p=0.008 n=5+5)
SelectPk/00100-12    97.1µs ± 2%    22.2µs ± 2%  -77.10%  (p=0.008 n=5+5)
SelectPk/01000-12     888µs ± 2%      22µs ± 1%  -97.52%  (p=0.008 n=5+5)
SelectPk/10000-12    9.18ms ± 3%    0.02ms ± 4%  -99.76%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
SelectPk/00001-12    4.18kB ± 0%    4.63kB ± 0%  +10.73%  (p=0.016 n=4+5)
SelectPk/00010-12    5.22kB ± 0%    4.63kB ± 0%  -11.34%  (p=0.008 n=5+5)
SelectPk/00100-12    15.7kB ± 0%     4.6kB ± 0%  -70.47%  (p=0.008 n=5+5)
SelectPk/01000-12     138kB ± 0%       5kB ± 0%  -96.64%  (p=0.008 n=5+5)
SelectPk/10000-12    1.37MB ± 0%    0.00MB ± 0%  -99.66%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
SelectPk/00001-12      90.0 ± 0%      95.0 ± 0%   +5.56%  (p=0.008 n=5+5)
SelectPk/00010-12       135 ± 0%        95 ± 0%  -29.63%  (p=0.008 n=5+5)
SelectPk/00100-12       585 ± 0%        95 ± 0%  -83.76%  (p=0.008 n=5+5)
SelectPk/01000-12     6.83k ± 0%     0.10k ± 0%  -98.58%  (p=0.008 n=5+5)
SelectPk/10000-12     69.8k ± 0%      0.1k ± 0%  -99.86%  (p=0.008 n=5+5)
```