### PR TITLE
Fix index state with UPDATE queries

### DIFF
--- a/database/table.go
+++ b/database/table.go
@@ -181,7 +181,7 @@ func (t *Table) replace(indexes []*Index, key []byte, d document.Document) error
 	for _, idx := range indexes {
 		v, err := idx.Info.Path.GetValueFromDocument(old)
 		if err != nil {
-			return err
+			v = document.NewNullValue()
 		}
 
 		err = idx.Delete(v, key)
@@ -209,16 +209,20 @@ func (t *Table) replace(indexes []*Index, key []byte, d document.Document) error
 	for _, idx := range indexes {
 		v, err := idx.Info.Path.GetValueFromDocument(d)
 		if err != nil {
-			continue
+			v = document.NewNullValue()
 		}
 
 		err = idx.Set(v, key)
 		if err != nil {
+			if err == ErrIndexDuplicateValue {
+				return ErrDuplicateDocument
+			}
+
 			return err
 		}
 	}
 
-	return err
+	return nil
 }
 
 type documentWithKey struct {

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -67,7 +67,6 @@ func (tx *Transaction) Rollback() error {
 // Commit the transaction. Calling this method on read-only transactions
 // will return an error.
 func (tx *Transaction) Commit() error {
-
 	err := tx.tx.Commit()
 	if err != nil {
 		return err

--- a/engine/boltengine/engine.go
+++ b/engine/boltengine/engine.go
@@ -214,9 +214,13 @@ func (t *Transaction) cleanupBinBucket() error {
 			buckets[string(bucketName)] = b
 		}
 
-		err := b.Delete(key)
-		if err != nil {
-			return err
+		// if the key has been rewritten during the lifecycle of the transaction
+		// do not delete it
+		if b.Get(key) == nil {
+			err := b.Delete(key)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/engine/enginetest/testing.go
+++ b/engine/enginetest/testing.go
@@ -857,6 +857,28 @@ func TestStoreIterator(t *testing.T, builder Builder) {
 		require.True(t, it.Valid())
 		require.Equal(t, it.Item().Key(), k)
 	})
+
+	t.Run("Iterating while deleting current key should work", func(t *testing.T) {
+		st, cleanup := storeBuilder(t, builder)
+		defer cleanup()
+
+		for i := 0; i < 50; i++ {
+			err := st.Put([]byte{byte(i)}, []byte{byte(i)})
+			require.NoError(t, err)
+		}
+
+		i := 0
+		it := st.Iterator(engine.IteratorOptions{})
+		defer it.Close()
+
+		for it.Seek(nil); it.Valid() && i < 50; it.Next() {
+			require.Equal(t, []byte{byte(i)}, it.Item().Key())
+
+			err := st.Delete([]byte{byte(i)})
+			require.NoError(t, err)
+			i++
+		}
+	})
 }
 
 // TestStorePut verifies Put behaviour.

--- a/engine/memoryengine/engine.go
+++ b/engine/memoryengine/engine.go
@@ -16,7 +16,7 @@ import (
 const btreeDegree = 12
 
 // Engine is a simple memory engine implementation that stores data in
-// an in-memory Btree. It allows multiple readers and one single writer.
+// an in-memory Btree. It is not thread safe.
 type Engine struct {
 	closed    bool
 	stores    map[string]*btree.BTree

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -236,11 +236,11 @@ func (it *iterator) Seek(pivot []byte) {
 	// is closed before creating a new one
 	if it.cancel != nil {
 		it.cancel()
-		it.ch = make(chan *item)
 		<-it.closed
-		it.closed = make(chan struct{})
 	}
 
+	it.ch = make(chan *item)
+	it.closed = make(chan struct{})
 	it.ctx, it.cancel = context.WithCancel(it.tx.ctx)
 
 	it.runIterator(pivot)

--- a/engine/memoryengine/store.go
+++ b/engine/memoryengine/store.go
@@ -158,7 +158,9 @@ func (s *storeTx) Delete(k []byte) error {
 
 	// on commit, remove the item from the tree.
 	s.tx.onCommit = append(s.tx.onCommit, func() {
-		s.tr.Delete(i)
+		if i.deleted {
+			s.tr.Delete(i)
+		}
 	})
 	return nil
 }

--- a/query/update_test.go
+++ b/query/update_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"bytes"
-	"database/sql"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -11,119 +10,153 @@ import (
 )
 
 func TestUpdateStmt(t *testing.T) {
-	tests := []struct {
-		name     string
-		query    string
-		fails    bool
-		expected string
-		params   []interface{}
-	}{
-		{"No clause", `UPDATE test`, true, "", nil},
-		{"Read-only table", `UPDATE __genji_tables SET a = 1`, true, "", nil},
+	// tests := []struct {
+	// 	name     string
+	// 	query    string
+	// 	fails    bool
+	// 	expected string
+	// 	params   []interface{}
+	// }{
+	// 	{"No clause", `UPDATE test`, true, "", nil},
+	// 	{"Read-only table", `UPDATE __genji_tables SET a = 1`, true, "", nil},
 
-		// SET tests.
-		{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
-		{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
-		{"SET / No cond / with multiple idents and constraint", `UPDATE test SET a = c`, true, ``, nil},
-		{"SET / No cond / with multiple idents", `UPDATE test SET b = c`, false, `[{"a":"foo1","b":"baz1","c":"baz1"},{"a":"foo2","b":null},{"a":"foo3","b":null,"d":"bar3","e":"baz3"}]`, nil},
-		{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
-		{"SET / No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
-		{"SET / With cond", "UPDATE test SET a = 'FOO2', b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"FOO2","b":2},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-		{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'bar3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
-		{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-		{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{"a", "b", "foo1"}},
-		{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
+	// 	// SET tests.
+	// 	{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
+	// 	{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
+	// 	{"SET / No cond / with multiple idents and constraint", `UPDATE test SET a = c`, true, ``, nil},
+	// 	{"SET / No cond / with multiple idents", `UPDATE test SET b = c`, false, `[{"a":"foo1","b":"baz1","c":"baz1"},{"a":"foo2","b":null},{"a":"foo3","b":null,"d":"bar3","e":"baz3"}]`, nil},
+	// 	{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
+	// 	{"SET / No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
+	// 	{"SET / With cond", "UPDATE test SET a = 'FOO2', b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"FOO2","b":2},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+	// 	{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'bar3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
+	// 	{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+	// 	{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{"a", "b", "foo1"}},
+	// 	{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
 
-		// UNSET tests.
-		{"UNSET / No cond", `UPDATE test UNSET b`, false, `[{"a":"foo1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-		{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", true, "", nil},
-		{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-		{"UNSET / No cond / with string", `UPDATE test UNSET 'a'`, true, "", nil},
-		{"UNSET / With cond", `UPDATE test UNSET b WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-	}
+	// 	// UNSET tests.
+	// 	{"UNSET / No cond", `UPDATE test UNSET b`, false, `[{"a":"foo1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+	// 	{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", true, "", nil},
+	// 	{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+	// 	{"UNSET / No cond / with string", `UPDATE test UNSET 'a'`, true, "", nil},
+	// 	{"UNSET / With cond", `UPDATE test UNSET b WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+	// }
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			db, err := genji.Open(":memory:")
-			require.NoError(t, err)
-			defer db.Close()
+	// for _, test := range tests {
+	// 	t.Run(test.name, func(t *testing.T) {
+	// 		runTest := func(indexed bool) {
+	// 			db, err := genji.Open(":memory:")
+	// 			require.NoError(t, err)
+	// 			defer db.Close()
 
-			err = db.Exec("CREATE TABLE test (a text not null)")
-			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
-			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
-			require.NoError(t, err)
-			err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
-			require.NoError(t, err)
+	// 			err = db.Exec("CREATE TABLE test (a text not null)")
+	// 			require.NoError(t, err)
 
-			err = db.Exec(test.query, test.params...)
-			if test.fails {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
+	// 			if indexed {
+	// 				err = db.Exec("CREATE INDEX idx_test_a ON test(a)")
+	// 				require.NoError(t, err)
+	// 			}
 
-			st, err := db.Query("SELECT * FROM test")
-			require.NoError(t, err)
-			defer st.Close()
+	// 			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+	// 			require.NoError(t, err)
+	// 			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
+	// 			require.NoError(t, err)
+	// 			err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
+	// 			require.NoError(t, err)
 
-			var buf bytes.Buffer
+	// 			err = db.Exec(test.query, test.params...)
+	// 			if test.fails {
+	// 				require.Error(t, err)
+	// 				return
+	// 			}
+	// 			require.NoError(t, err)
 
-			err = document.IteratorToJSONArray(&buf, st)
-			require.NoError(t, err)
-			require.JSONEq(t, test.expected, buf.String())
-		})
-	}
+	// 			st, err := db.Query("SELECT * FROM test")
+	// 			require.NoError(t, err)
+	// 			defer st.Close()
 
-	t.Run("with arrays", func(t *testing.T) {
-		tests := []struct {
-			name     string
-			query    string
-			fails    bool
-			expected string
-			params   []interface{}
-		}{
-			{"SET / No cond add field ", `UPDATE foo set b = 0`, false, `[{"a": [1, 0, 0], "b": 0}, {"a": [2, 0], "b": 0}]`, nil},
-			{"SET / No cond / with path at existing index only", `UPDATE foo SET a[2] = 10`, false, `[{"a": [1, 0, 10]}, {"a": [2, 0]}]`, nil},
-			{"SET / No cond / with index array", `UPDATE foo SET a[1] = 10`, false, `[{"a": [1, 10, 0]}, {"a": [2, 10]}]`, nil},
-			{"SET / No cond / with path on non existing field", `UPDATE foo SET a.foo[1] = 10`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
-			{"SET / With cond / index array", `UPDATE foo SET a[0] = 1 WHERE a[0] = 2`, false, `[{"a": [1, 0, 0]}, {"a": [1, 0]}]`, nil},
-			{"SET / No cond / index out of range", `UPDATE foo SET a[10] = 1`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
-			{"SET / No cond / Nested array", `UPDATE foo SET a[1] = [1, 0, 0]`, false, `[{"a": [1, [1, 0, 0], 0]}, {"a": [2, [1, 0, 0]]}]`, nil},
-			{"SET / No cond / with multiple idents", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = 9`, false, `[{"a": [1, [1, 0, 9], 0]}, {"a": [2, [1, 0, 9]]}]`, nil},
-			{"SET / No cond / add doc / with multiple idents with multiple indexes", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = {"b": "foo"}`, false, `[{"a": [1, [1, 0, {"b":"foo"}], 0]}, {"a": [2, [1, 0, {"b":"foo"}]]}]`, nil},
-		}
+	// 			var buf bytes.Buffer
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				db, err := genji.Open(":memory:")
-				require.NoError(t, err)
-				defer db.Close()
+	// 			err = document.IteratorToJSONArray(&buf, st)
+	// 			require.NoError(t, err)
+	// 			require.JSONEq(t, test.expected, buf.String())
+	// 		}
 
-				err = db.Exec(`CREATE TABLE foo;`)
-				require.NoError(t, err)
-				err = db.Exec(`INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
-				require.NoError(t, err)
+	// 		runTest(false)
+	// 		runTest(true)
+	// 	})
+	// }
 
-				err = db.Exec(tt.query, tt.params...)
-				if tt.fails {
-					require.Error(t, err)
-					return
-				}
-				require.NoError(t, err)
+	// t.Run("with arrays", func(t *testing.T) {
+	// 	tests := []struct {
+	// 		name     string
+	// 		query    string
+	// 		fails    bool
+	// 		expected string
+	// 		params   []interface{}
+	// 	}{
+	// 		{"SET / No cond add field ", `UPDATE foo set b = 0`, false, `[{"a": [1, 0, 0], "b": 0}, {"a": [2, 0], "b": 0}]`, nil},
+	// 		{"SET / No cond / with path at existing index only", `UPDATE foo SET a[2] = 10`, false, `[{"a": [1, 0, 10]}, {"a": [2, 0]}]`, nil},
+	// 		{"SET / No cond / with index array", `UPDATE foo SET a[1] = 10`, false, `[{"a": [1, 10, 0]}, {"a": [2, 10]}]`, nil},
+	// 		{"SET / No cond / with path on non existing field", `UPDATE foo SET a.foo[1] = 10`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
+	// 		{"SET / With cond / index array", `UPDATE foo SET a[0] = 1 WHERE a[0] = 2`, false, `[{"a": [1, 0, 0]}, {"a": [1, 0]}]`, nil},
+	// 		{"SET / No cond / index out of range", `UPDATE foo SET a[10] = 1`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
+	// 		{"SET / No cond / Nested array", `UPDATE foo SET a[1] = [1, 0, 0]`, false, `[{"a": [1, [1, 0, 0], 0]}, {"a": [2, [1, 0, 0]]}]`, nil},
+	// 		{"SET / No cond / with multiple idents", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = 9`, false, `[{"a": [1, [1, 0, 9], 0]}, {"a": [2, [1, 0, 9]]}]`, nil},
+	// 		{"SET / No cond / add doc / with multiple idents with multiple indexes", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = {"b": "foo"}`, false, `[{"a": [1, [1, 0, {"b":"foo"}], 0]}, {"a": [2, [1, 0, {"b":"foo"}]]}]`, nil},
+	// 	}
 
-				st, err := db.Query("SELECT * FROM foo")
-				require.NoError(t, err)
-				defer st.Close()
+	// 	for _, tt := range tests {
+	// 		t.Run(tt.name, func(t *testing.T) {
+	// 			db, err := genji.Open(":memory:")
+	// 			require.NoError(t, err)
+	// 			defer db.Close()
 
-				var buf bytes.Buffer
+	// 			err = db.Exec(`CREATE TABLE foo;`)
+	// 			require.NoError(t, err)
+	// 			err = db.Exec(`INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
+	// 			require.NoError(t, err)
 
-				err = document.IteratorToJSONArray(&buf, st)
-				require.NoError(t, err)
-				require.JSONEq(t, tt.expected, buf.String())
-			})
+	// 			err = db.Exec(tt.query, tt.params...)
+	// 			if tt.fails {
+	// 				require.Error(t, err)
+	// 				return
+	// 			}
+	// 			require.NoError(t, err)
 
-		}
+	// 			st, err := db.Query("SELECT * FROM foo")
+	// 			require.NoError(t, err)
+	// 			defer st.Close()
+
+	// 			var buf bytes.Buffer
+
+	// 			err = document.IteratorToJSONArray(&buf, st)
+	// 			require.NoError(t, err)
+	// 			require.JSONEq(t, tt.expected, buf.String())
+	// 		})
+
+	// 	}
+	// })
+
+	// cf https://github.com/genjidb/genji/issues/345
+	t.Run("update non-indexed field then select through indexed field", func(t *testing.T) {
+		db, err := genji.Open(":memory:")
+		require.NoError(t, err)
+		defer db.Close()
+
+		res, err := db.Query(`
+			CREATE TABLE foo;
+			CREATE UNIQUE INDEX idx_foo_a ON foo(a);
+			INSERT INTO foo(a, b) VALUES (1, 1), (2, 2);
+			UPDATE foo SET b = 3 WHERE a = 1;
+			SELECT * FROM foo WHERE a = 1;
+		`)
+		require.NoError(t, err)
+		defer res.Close()
+
+		var buf bytes.Buffer
+
+		err = document.IteratorToJSONArray(&buf, res)
+		require.NoError(t, err)
+		require.JSONEq(t, `[{"a": 1, "b": 3}]`, buf.String())
 	})
 }

--- a/query/update_test.go
+++ b/query/update_test.go
@@ -2,6 +2,7 @@ package query_test
 
 import (
 	"bytes"
+	"database/sql"
 	"testing"
 
 	"github.com/genjidb/genji"
@@ -10,153 +11,129 @@ import (
 )
 
 func TestUpdateStmt(t *testing.T) {
-	// tests := []struct {
-	// 	name     string
-	// 	query    string
-	// 	fails    bool
-	// 	expected string
-	// 	params   []interface{}
-	// }{
-	// 	{"No clause", `UPDATE test`, true, "", nil},
-	// 	{"Read-only table", `UPDATE __genji_tables SET a = 1`, true, "", nil},
+	tests := []struct {
+		name     string
+		query    string
+		fails    bool
+		expected string
+		params   []interface{}
+	}{
+		{"No clause", `UPDATE test`, true, "", nil},
+		{"Read-only table", `UPDATE __genji_tables SET a = 1`, true, "", nil},
 
-	// 	// SET tests.
-	// 	{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
-	// 	{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
-	// 	{"SET / No cond / with multiple idents and constraint", `UPDATE test SET a = c`, true, ``, nil},
-	// 	{"SET / No cond / with multiple idents", `UPDATE test SET b = c`, false, `[{"a":"foo1","b":"baz1","c":"baz1"},{"a":"foo2","b":null},{"a":"foo3","b":null,"d":"bar3","e":"baz3"}]`, nil},
-	// 	{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
-	// 	{"SET / No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
-	// 	{"SET / With cond", "UPDATE test SET a = 'FOO2', b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"FOO2","b":2},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-	// 	{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'bar3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
-	// 	{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-	// 	{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{"a", "b", "foo1"}},
-	// 	{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
+		// SET tests.
+		{"SET / No cond", `UPDATE test SET a = 'boo'`, false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / No cond / with ident string", "UPDATE test SET `a` = 'boo'", false, `[{"a":"boo","b":"bar1","c":"baz1"},{"a":"boo","b":"bar2"},{"a":"boo","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / No cond / with multiple idents and constraint", `UPDATE test SET a = c`, true, ``, nil},
+		{"SET / No cond / with multiple idents", `UPDATE test SET b = c`, false, `[{"a":"foo1","b":"baz1","c":"baz1"},{"a":"foo2","b":null},{"a":"foo3","b":null,"d":"bar3","e":"baz3"}]`, nil},
+		{"SET / No cond / with missing field", "UPDATE test SET f = 'boo'", false, `[{"a":"foo1","b":"bar1","c":"baz1","f":"boo"},{"a":"foo2","b":"bar2","f":"boo"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
+		{"SET / No cond / with string", `UPDATE test SET 'a' = 'boo'`, true, "", nil},
+		{"SET / With cond", "UPDATE test SET a = 'FOO2', b = 2 WHERE a = 'foo2'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"FOO2","b":2},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / With cond / with missing field", "UPDATE test SET f = 'boo' WHERE d = 'bar3'", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3","f":"boo"}]`, nil},
+		{"SET / Field not found", "UPDATE test SET a = 1, b = 2 WHERE a = f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"SET / Positional params", "UPDATE test SET a = ?, b = ? WHERE a = ?", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{"a", "b", "foo1"}},
+		{"SET / Named params", "UPDATE test SET a = $a, b = $b WHERE a = $c", false, `[{"a":"a","b":"b","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, []interface{}{sql.Named("b", "b"), sql.Named("a", "a"), sql.Named("c", "foo1")}},
 
-	// 	// UNSET tests.
-	// 	{"UNSET / No cond", `UPDATE test UNSET b`, false, `[{"a":"foo1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-	// 	{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", true, "", nil},
-	// 	{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-	// 	{"UNSET / No cond / with string", `UPDATE test UNSET 'a'`, true, "", nil},
-	// 	{"UNSET / With cond", `UPDATE test UNSET b WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
-	// }
+		// UNSET tests.
+		{"UNSET / No cond", `UPDATE test UNSET b`, false, `[{"a":"foo1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"UNSET / No cond / with ident string", "UPDATE test UNSET `a`", true, "", nil},
+		{"UNSET / No cond / with missing field", "UPDATE test UNSET f", false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2","b":"bar2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+		{"UNSET / No cond / with string", `UPDATE test UNSET 'a'`, true, "", nil},
+		{"UNSET / With cond", `UPDATE test UNSET b WHERE a = 'foo2'`, false, `[{"a":"foo1","b":"bar1","c":"baz1"},{"a":"foo2"},{"a":"foo3","d":"bar3","e":"baz3"}]`, nil},
+	}
 
-	// for _, test := range tests {
-	// 	t.Run(test.name, func(t *testing.T) {
-	// 		runTest := func(indexed bool) {
-	// 			db, err := genji.Open(":memory:")
-	// 			require.NoError(t, err)
-	// 			defer db.Close()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTest := func(indexed bool) {
+				db, err := genji.Open(":memory:")
+				require.NoError(t, err)
+				defer db.Close()
 
-	// 			err = db.Exec("CREATE TABLE test (a text not null)")
-	// 			require.NoError(t, err)
+				err = db.Exec("CREATE TABLE test (a text not null)")
+				require.NoError(t, err)
 
-	// 			if indexed {
-	// 				err = db.Exec("CREATE INDEX idx_test_a ON test(a)")
-	// 				require.NoError(t, err)
-	// 			}
+				if indexed {
+					err = db.Exec("CREATE INDEX idx_test_a ON test(a)")
+					require.NoError(t, err)
+				}
 
-	// 			err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
-	// 			require.NoError(t, err)
-	// 			err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
-	// 			require.NoError(t, err)
-	// 			err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
-	// 			require.NoError(t, err)
+				err = db.Exec("INSERT INTO test (a, b, c) VALUES ('foo1', 'bar1', 'baz1')")
+				require.NoError(t, err)
+				err = db.Exec("INSERT INTO test (a, b) VALUES ('foo2', 'bar2')")
+				require.NoError(t, err)
+				err = db.Exec("INSERT INTO test (a, d, e) VALUES ('foo3', 'bar3', 'baz3')")
+				require.NoError(t, err)
 
-	// 			err = db.Exec(test.query, test.params...)
-	// 			if test.fails {
-	// 				require.Error(t, err)
-	// 				return
-	// 			}
-	// 			require.NoError(t, err)
+				err = db.Exec(test.query, test.params...)
+				if test.fails {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
 
-	// 			st, err := db.Query("SELECT * FROM test")
-	// 			require.NoError(t, err)
-	// 			defer st.Close()
+				st, err := db.Query("SELECT * FROM test")
+				require.NoError(t, err)
+				defer st.Close()
 
-	// 			var buf bytes.Buffer
+				var buf bytes.Buffer
 
-	// 			err = document.IteratorToJSONArray(&buf, st)
-	// 			require.NoError(t, err)
-	// 			require.JSONEq(t, test.expected, buf.String())
-	// 		}
+				err = document.IteratorToJSONArray(&buf, st)
+				require.NoError(t, err)
+				require.JSONEq(t, test.expected, buf.String())
+			}
 
-	// 		runTest(false)
-	// 		runTest(true)
-	// 	})
-	// }
+			runTest(false)
+			runTest(true)
+		})
+	}
 
-	// t.Run("with arrays", func(t *testing.T) {
-	// 	tests := []struct {
-	// 		name     string
-	// 		query    string
-	// 		fails    bool
-	// 		expected string
-	// 		params   []interface{}
-	// 	}{
-	// 		{"SET / No cond add field ", `UPDATE foo set b = 0`, false, `[{"a": [1, 0, 0], "b": 0}, {"a": [2, 0], "b": 0}]`, nil},
-	// 		{"SET / No cond / with path at existing index only", `UPDATE foo SET a[2] = 10`, false, `[{"a": [1, 0, 10]}, {"a": [2, 0]}]`, nil},
-	// 		{"SET / No cond / with index array", `UPDATE foo SET a[1] = 10`, false, `[{"a": [1, 10, 0]}, {"a": [2, 10]}]`, nil},
-	// 		{"SET / No cond / with path on non existing field", `UPDATE foo SET a.foo[1] = 10`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
-	// 		{"SET / With cond / index array", `UPDATE foo SET a[0] = 1 WHERE a[0] = 2`, false, `[{"a": [1, 0, 0]}, {"a": [1, 0]}]`, nil},
-	// 		{"SET / No cond / index out of range", `UPDATE foo SET a[10] = 1`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
-	// 		{"SET / No cond / Nested array", `UPDATE foo SET a[1] = [1, 0, 0]`, false, `[{"a": [1, [1, 0, 0], 0]}, {"a": [2, [1, 0, 0]]}]`, nil},
-	// 		{"SET / No cond / with multiple idents", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = 9`, false, `[{"a": [1, [1, 0, 9], 0]}, {"a": [2, [1, 0, 9]]}]`, nil},
-	// 		{"SET / No cond / add doc / with multiple idents with multiple indexes", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = {"b": "foo"}`, false, `[{"a": [1, [1, 0, {"b":"foo"}], 0]}, {"a": [2, [1, 0, {"b":"foo"}]]}]`, nil},
-	// 	}
+	t.Run("with arrays", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			query    string
+			fails    bool
+			expected string
+			params   []interface{}
+		}{
+			{"SET / No cond add field ", `UPDATE foo set b = 0`, false, `[{"a": [1, 0, 0], "b": 0}, {"a": [2, 0], "b": 0}]`, nil},
+			{"SET / No cond / with path at existing index only", `UPDATE foo SET a[2] = 10`, false, `[{"a": [1, 0, 10]}, {"a": [2, 0]}]`, nil},
+			{"SET / No cond / with index array", `UPDATE foo SET a[1] = 10`, false, `[{"a": [1, 10, 0]}, {"a": [2, 10]}]`, nil},
+			{"SET / No cond / with path on non existing field", `UPDATE foo SET a.foo[1] = 10`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
+			{"SET / With cond / index array", `UPDATE foo SET a[0] = 1 WHERE a[0] = 2`, false, `[{"a": [1, 0, 0]}, {"a": [1, 0]}]`, nil},
+			{"SET / No cond / index out of range", `UPDATE foo SET a[10] = 1`, false, `[{"a": [1, 0, 0]}, {"a": [2, 0]}]`, nil},
+			{"SET / No cond / Nested array", `UPDATE foo SET a[1] = [1, 0, 0]`, false, `[{"a": [1, [1, 0, 0], 0]}, {"a": [2, [1, 0, 0]]}]`, nil},
+			{"SET / No cond / with multiple idents", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = 9`, false, `[{"a": [1, [1, 0, 9], 0]}, {"a": [2, [1, 0, 9]]}]`, nil},
+			{"SET / No cond / add doc / with multiple idents with multiple indexes", `UPDATE foo SET a[1] = [1, 0, 0], a[1][2] = {"b": "foo"}`, false, `[{"a": [1, [1, 0, {"b":"foo"}], 0]}, {"a": [2, [1, 0, {"b":"foo"}]]}]`, nil},
+		}
 
-	// 	for _, tt := range tests {
-	// 		t.Run(tt.name, func(t *testing.T) {
-	// 			db, err := genji.Open(":memory:")
-	// 			require.NoError(t, err)
-	// 			defer db.Close()
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				db, err := genji.Open(":memory:")
+				require.NoError(t, err)
+				defer db.Close()
 
-	// 			err = db.Exec(`CREATE TABLE foo;`)
-	// 			require.NoError(t, err)
-	// 			err = db.Exec(`INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
-	// 			require.NoError(t, err)
+				err = db.Exec(`CREATE TABLE foo;`)
+				require.NoError(t, err)
+				err = db.Exec(`INSERT INTO foo (a) VALUES ([1, 0, 0]), ([2, 0]);`)
+				require.NoError(t, err)
 
-	// 			err = db.Exec(tt.query, tt.params...)
-	// 			if tt.fails {
-	// 				require.Error(t, err)
-	// 				return
-	// 			}
-	// 			require.NoError(t, err)
+				err = db.Exec(tt.query, tt.params...)
+				if tt.fails {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
 
-	// 			st, err := db.Query("SELECT * FROM foo")
-	// 			require.NoError(t, err)
-	// 			defer st.Close()
+				st, err := db.Query("SELECT * FROM foo")
+				require.NoError(t, err)
+				defer st.Close()
 
-	// 			var buf bytes.Buffer
+				var buf bytes.Buffer
 
-	// 			err = document.IteratorToJSONArray(&buf, st)
-	// 			require.NoError(t, err)
-	// 			require.JSONEq(t, tt.expected, buf.String())
-	// 		})
-
-	// 	}
-	// })
-
-	// cf https://github.com/genjidb/genji/issues/345
-	t.Run("update non-indexed field then select through indexed field", func(t *testing.T) {
-		db, err := genji.Open(":memory:")
-		require.NoError(t, err)
-		defer db.Close()
-
-		res, err := db.Query(`
-			CREATE TABLE foo;
-			CREATE UNIQUE INDEX idx_foo_a ON foo(a);
-			INSERT INTO foo(a, b) VALUES (1, 1), (2, 2);
-			UPDATE foo SET b = 3 WHERE a = 1;
-			SELECT * FROM foo WHERE a = 1;
-		`)
-		require.NoError(t, err)
-		defer res.Close()
-
-		var buf bytes.Buffer
-
-		err = document.IteratorToJSONArray(&buf, res)
-		require.NoError(t, err)
-		require.JSONEq(t, `[{"a": 1, "b": 3}]`, buf.String())
+				err = document.IteratorToJSONArray(&buf, st)
+				require.NoError(t, err)
+				require.JSONEq(t, tt.expected, buf.String())
+			})
+		}
 	})
 }

--- a/testutil/document.go
+++ b/testutil/document.go
@@ -1,7 +1,9 @@
 package testutil
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/genjidb/genji/document"
@@ -53,4 +55,14 @@ func (docs Docs) RequireEqual(t testing.TB, others Docs) {
 			require.Equal(t, l, r)
 		}
 	}
+}
+
+// Dump a json representation of v to os.Stdout.
+func Dump(t testing.TB, v interface{}) {
+	t.Helper()
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	err := enc.Encode(v)
+	require.NoError(t, err)
 }

--- a/testutil/index.go
+++ b/testutil/index.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/genjidb/genji/database"
+	"github.com/genjidb/genji/document"
+	"github.com/stretchr/testify/require"
+)
+
+// GetIndexContent iterates over the entire index and returns all the key-value pairs in order.
+func GetIndexContent(t testing.TB, tx *database.Transaction, indexName string) []KV {
+	t.Helper()
+
+	idx, err := tx.GetIndex(indexName)
+	require.NoError(t, err)
+
+	var content []KV
+	err = idx.AscendGreaterOrEqual(document.Value{}, func(val, key []byte) error {
+		content = append(content, KV{
+			Key:   append([]byte{}, val...),
+			Value: append([]byte{}, key...),
+		})
+		return nil
+	})
+	require.NoError(t, err)
+
+	return content
+}

--- a/testutil/misc.go
+++ b/testutil/misc.go
@@ -1,0 +1,6 @@
+package testutil
+
+// KV is used to represent key-value pairs stored in tables or indexes.
+type KV struct {
+	Key, Value []byte
+}


### PR DESCRIPTION
This fixes how UPDATE queries on indexed tables would cause some indexes to be in an incorrect state.
This was caused by the "trash bin" mechanism implemented in both bolt and memory engines, where nodes would get marked as deleted without modifying the btree and then actually removed when the transaction is committed.
The error occurred when a key was marked for deletion and then overwritten (which happens a lot when we run UPDATE on indexed fields that are not modified), the cleanup mechanism would delete them even when it's not supposed to.
This PR also fixes a race condition occurring in the memory engine.

Fixes https://github.com/genjidb/genji/issues/355