### PR TITLE
Small performance improvements

### DIFF
--- a/document/encoding/codec.go
+++ b/document/encoding/codec.go
@@ -16,7 +16,7 @@ type Codec interface {
 	// NewDocument returns a document without decoding its given binary representation.
 	// The returned document should ideally support random-access, i.e. decoding one path
 	// without decoding the entire document. If not, the document must be lazily decoded.
-	NewDocument([]byte) document.Document
+	NewDecoder([]byte) Decoder
 }
 
 // An Encoder encodes one document to the underlying writer.
@@ -24,4 +24,13 @@ type Encoder interface {
 	EncodeDocument(d document.Document) error
 	// Close the encoder to release any resource.
 	Close()
+}
+
+// A Decoder represents an encoded document that can
+// be used as if it was decoded.
+// Decoders can be reused to read different documents.
+type Decoder interface {
+	document.Document
+
+	Reset([]byte)
 }

--- a/document/encoding/custom/format.go
+++ b/document/encoding/custom/format.go
@@ -168,7 +168,6 @@ func (f *FieldHeader) Decode(data []byte) (int, error) {
 	if n <= 0 {
 		return 0, errors.New("cannot decode data")
 	}
-	data = data[n:]
 	read += n
 
 	return read, nil

--- a/document/encoding/encodingtest/benchmark.go
+++ b/document/encoding/encodingtest/benchmark.go
@@ -64,7 +64,7 @@ func benchmarkDocumentGetByField(b *testing.B, codecBuilder func() encoding.Code
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		codec.NewDocument(buf.Bytes()).GetByField("name-99")
+		codec.NewDecoder(buf.Bytes()).GetByField("name-99")
 	}
 }
 
@@ -80,7 +80,7 @@ func benchmarkDocumentIterate(b *testing.B, codecBuilder func() encoding.Codec) 
 	err := codec.NewEncoder(&buf).EncodeDocument(&fb)
 	require.NoError(b, err)
 
-	doc := codec.NewDocument(buf.Bytes())
+	doc := codec.NewDecoder(buf.Bytes())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -102,7 +102,7 @@ func benchmarkDecodeDocument(b *testing.B, codecBuilder func() encoding.Codec) {
 	err := codec.NewEncoder(&buf).EncodeDocument(&fb)
 	require.NoError(b, err)
 
-	doc := codec.NewDocument(buf.Bytes())
+	doc := codec.NewDecoder(buf.Bytes())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/document/encoding/encodingtest/testing.go
+++ b/document/encoding/encodingtest/testing.go
@@ -87,10 +87,10 @@ func testEncodeDecode(t *testing.T, codecBuilder func() encoding.Codec) {
 			codec := codecBuilder()
 			err := codec.NewEncoder(&buf).EncodeDocument(test.d)
 			require.NoError(t, err)
-			ok, err := document.NewDocumentValue(test.d).IsEqual(document.NewDocumentValue(codec.NewDocument(buf.Bytes())))
+			ok, err := document.NewDocumentValue(test.d).IsEqual(document.NewDocumentValue(codec.NewDecoder(buf.Bytes())))
 			require.NoError(t, err)
 			require.True(t, ok)
-			data, err := document.MarshalJSON(codec.NewDocument(buf.Bytes()))
+			data, err := document.MarshalJSON(codec.NewDecoder(buf.Bytes()))
 			require.NoError(t, err)
 			require.JSONEq(t, test.expected, string(data))
 		})
@@ -110,7 +110,7 @@ func testDocumentGetByField(t *testing.T, codecBuilder func() encoding.Codec) {
 	err := codec.NewEncoder(&buf).EncodeDocument(fb)
 	require.NoError(t, err)
 
-	d := codec.NewDocument(buf.Bytes())
+	d := codec.NewDecoder(buf.Bytes())
 
 	v, err := d.GetByField("a")
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func testArrayGetByIndex(t *testing.T, codecBuilder func() encoding.Codec) {
 	err := codec.NewEncoder(&buf).EncodeDocument(document.NewFieldBuffer().Add("a", document.NewArrayValue(arr)))
 	require.NoError(t, err)
 
-	d := codec.NewDocument(buf.Bytes())
+	d := codec.NewDecoder(buf.Bytes())
 	v, err := d.GetByField("a")
 	require.NoError(t, err)
 
@@ -187,7 +187,7 @@ func testDecodeDocument(t *testing.T, codecBuilder func() encoding.Codec) {
 	err = enc.EncodeDocument(doc)
 	require.NoError(t, err)
 
-	ec := codec.NewDocument(buf.Bytes())
+	ec := codec.NewDecoder(buf.Bytes())
 	v, err := ec.GetByField("age")
 	require.NoError(t, err)
 	require.Equal(t, document.NewIntegerValue(10), v)

--- a/document/encoding/msgpack/codec.go
+++ b/document/encoding/msgpack/codec.go
@@ -24,8 +24,8 @@ func (c Codec) NewEncoder(w io.Writer) encoding.Encoder {
 }
 
 // NewDocument implements the encoding.Codec interface.
-func (c Codec) NewDocument(data []byte) document.Document {
-	return EncodedDocument(data)
+func (c Codec) NewDecoder(data []byte) encoding.Decoder {
+	return NewEncodedDocument(data)
 }
 
 // Encoder encodes Genji documents and values
@@ -258,7 +258,7 @@ func (d *Decoder) DecodeDocument() (document.Document, error) {
 		return nil, err
 	}
 
-	return EncodedDocument(r), nil
+	return NewEncodedDocument(r), nil
 }
 
 // DecodeArray decodes one array from the reader.

--- a/document/encoding/msgpack/encoding_test.go
+++ b/document/encoding/msgpack/encoding_test.go
@@ -35,7 +35,8 @@ func TestCompactedIntDecoding(t *testing.T) {
 	err := codec.NewEncoder(&buf).EncodeDocument(d)
 	require.NoError(t, err)
 
-	data, err := document.MarshalJSON(codec.NewDocument(buf.Bytes()))
+	doc := codec.NewDecoder(buf.Bytes())
+	data, err := document.MarshalJSON(doc)
 	require.NoError(t, err)
 	require.JSONEq(t, expected, string(data))
 }

--- a/document/scan_test.go
+++ b/document/scan_test.go
@@ -75,7 +75,7 @@ func TestScan(t *testing.T) {
 		)).
 		Add("o", document.NewNullValue()).
 		Add("p", document.NewTextValue(now.Format(time.RFC3339Nano))).
-		Add("r", document.NewDocumentValue(codec.NewDocument(buf.Bytes()))).
+		Add("r", document.NewDocumentValue(codec.NewDecoder(buf.Bytes()))).
 		Add("s", document.NewArrayValue(document.NewValueBuffer(document.NewBoolValue(true), document.NewBoolValue(false)))).
 		Add("u", document.NewArrayValue(document.NewValueBuffer(
 			document.NewDocumentValue(

--- a/internal/database/index.go
+++ b/internal/database/index.go
@@ -244,7 +244,7 @@ func (idx *Index) Delete(vs []document.Value, k []byte) error {
 	var toDelete []byte
 	var buf []byte
 	err = idx.iterate(st, vs, false, func(item engine.Item) error {
-		buf, err = item.ValueCopy(buf[:0])
+		buf, err = item.ValueCopy(buf)
 		if err != nil {
 			return err
 		}
@@ -375,7 +375,7 @@ func (idx *Index) iterateOnStore(pivot Pivot, reverse bool, fn func(val, key []b
 			k = k[:len(k)-int(n)-1]
 		}
 
-		buf, err = item.ValueCopy(buf[:0])
+		buf, err = item.ValueCopy(buf)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The codec interface has been modified to allow the reuse of buffers when decoding
documents one by one from a table.

Memory consumption has been reduced drastically (-60%) and iteration speed has been improved by 20%

```
name                          old time/op    new time/op    delta
PreparedSelectWhere/00001-12    8.28µs ± 0%    7.24µs ± 0%  -12.51%  (p=1.000 n=1+1)
PreparedSelectWhere/00010-12    14.3µs ± 0%    12.7µs ± 0%  -11.16%  (p=1.000 n=1+1)
PreparedSelectWhere/00100-12    91.7µs ± 0%    77.3µs ± 0%  -15.65%  (p=1.000 n=1+1)
PreparedSelectWhere/01000-12     862µs ± 0%     728µs ± 0%  -15.55%  (p=1.000 n=1+1)
PreparedSelectWhere/10000-12    9.08ms ± 0%    7.34ms ± 0%  -19.13%  (p=1.000 n=1+1)

name                          old alloc/op   new alloc/op   delta
PreparedSelectWhere/00001-12    1.64kB ± 0%    1.69kB ± 0%   +3.43%  (p=1.000 n=1+1)
PreparedSelectWhere/00010-12    2.93kB ± 0%    1.83kB ± 0%  -37.47%  (p=1.000 n=1+1)
PreparedSelectWhere/00100-12    15.9kB ± 0%     3.3kB ± 0%  -79.41%  (p=1.000 n=1+1)
PreparedSelectWhere/01000-12     146kB ± 0%      18kB ± 0%  -87.85%  (p=1.000 n=1+1)
PreparedSelectWhere/10000-12    1.45MB ± 0%    0.16MB ± 0%  -88.76%  (p=1.000 n=1+1)

name                          old allocs/op  new allocs/op  delta
PreparedSelectWhere/00001-12      32.0 ± 0%      30.0 ± 0%   -6.25%  (p=1.000 n=1+1)
PreparedSelectWhere/00010-12      86.0 ± 0%      48.0 ± 0%  -44.19%  (p=1.000 n=1+1)
PreparedSelectWhere/00100-12       626 ± 0%       228 ± 0%  -63.58%  (p=1.000 n=1+1)
PreparedSelectWhere/01000-12     6.03k ± 0%     2.03k ± 0%  -66.35%  (p=1.000 n=1+1)
PreparedSelectWhere/10000-12     60.0k ± 0%     20.0k ± 0%  -66.64%  (p=1.000 n=1+1)
```