### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ func main() {
 
 ```go
 // import Genji as a blank import
-import _ "github.com/genjidb/genji/driver"
+import _ "github.com/genjidb/genji/sql/driver"
 
 // Create a sql/database DB instance
 db, err := sql.Open("genji", "my.db")


### PR DESCRIPTION
The example using `database/sql` does not have the correct import path for the driver