### PR TITLE
Use document.Iterator for scanDocument

### DIFF
--- a/db.go
+++ b/db.go
@@ -241,9 +241,9 @@ func (s *Statement) QueryDocument(args ...interface{}) (d document.Document, err
 	return scanDocument(res)
 }
 
-func scanDocument(res *Result) (document.Document, error) {
+func scanDocument(iter document.Iterator) (document.Document, error) {
 	var d document.Document
-	err := res.Iterate(func(doc document.Document) error {
+	err := iter.Iterate(func(doc document.Document) error {
 		d = doc
 		return stream.ErrStreamClosed
 	})


### PR DESCRIPTION
👋 @asdine,

Genji is sweet ❤️ You rock, man.

It seems `scanDocument` only needs to call `Iterate` on `*Result`. Why not passing a `document.Iterator` instead? As the function is called `scanDocument` and returns a `document.Document`, taking a `document.Iterator` as argument looks a bit more `document` API friendly.

Cheers 🏖️ 