### PR TITLE
Remove unused code from document/FieldBuffer.Delete

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -307,7 +307,6 @@ func (fb *FieldBuffer) Delete(path Path) error {
 			return ErrFieldNotFound
 		}
 		subBuf.Values = append(subBuf.Values[0:idx], subBuf.Values[idx+1:]...)
-		parentPath[:len(parentPath)-1].GetValueFromDocument(fb)
 	default:
 		return ErrFieldNotFound
 	}


### PR DESCRIPTION
In `document/FieldBuffer.Delete`, the return value of `parentPath[:len(parentPath)-1].GetValueFromDocument(fb)` is never used. I suspect a forgotten line or an unhandled case that should be handled (and I'm ready to work on this issue if so).