### PR TITLE
Add more math functions 

### DIFF
--- a/cmd/genji/doc/doc_test.go
+++ b/cmd/genji/doc/doc_test.go
@@ -2,6 +2,7 @@ package doc_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/genjidb/genji/cmd/genji/doc"
@@ -15,24 +16,32 @@ func TestFunctions(t *testing.T) {
 	for pkgname, pkg := range packages {
 		for fname, def := range pkg {
 			if pkgname == "" {
-				t.Run(fmt.Sprintf("%s has all its arguments mentioned", fname), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%s is documented and has all its arguments mentioned", fname), func(t *testing.T) {
 					str, err := doc.DocString(fname)
 					require.NoError(t, err)
 					for i := 0; i < def.Arity(); i++ {
-						require.Contains(t, str, fmt.Sprintf("arg%d", i+1))
+						require.Contains(t, trimDocPromt(str), fmt.Sprintf("arg%d", i+1))
 					}
 				})
 			} else {
-				t.Run(fmt.Sprintf("%s.%s has all its arguments mentioned", pkgname, fname), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%s.%s is documented and has all its arguments mentioned", pkgname, fname), func(t *testing.T) {
 					str, err := doc.DocString(fmt.Sprintf("%s.%s", pkgname, fname))
 					require.NoError(t, err)
 					for i := 0; i < def.Arity(); i++ {
-						require.Contains(t, str, fmt.Sprintf("arg%d", i+1))
+						require.Contains(t, trimDocPromt(str), fmt.Sprintf("arg%d", i+1))
 					}
 				})
 			}
 		}
 	}
+}
+
+// trimDocPrompt returns the description part of the doc string, ignoring the promt.
+func trimDocPromt(str string) string {
+	// Matches the doc description, ignoring the "package.funcname:" part.
+	r := regexp.MustCompile("[^:]+:(.*)")
+	subs := r.FindStringSubmatch(str)
+	return subs[1]
 }
 
 func TestTokens(t *testing.T) {

--- a/cmd/genji/doc/functions.go
+++ b/cmd/genji/doc/functions.go
@@ -10,12 +10,19 @@ var packageDocs = map[string]functionDocs{
 var builtinDocs = functionDocs{
 	"pk":    "The pk() function returns the primary key for the current document",
 	"count": "Returns a count of the number of times that arg1 is not NULL in a group. The count(*) function (with no arguments) returns the total number of rows in the group.",
-	"min":   "Returns the minimum value in a group.",
-	"max":   "Returns the maximum value in a group.",
-	"sum":   "The sum function returns the sum of all values in a group.",
-	"avg":   "The avg function returns the average of all values in a group.",
+	"min":   "Returns the minimum value of the arg1 expression in a group.",
+	"max":   "Returns the maximum value of the arg1 expressein in a group.",
+	"sum":   "The sum function returns the sum of all values taken by the arg1 expression in a group.",
+	"avg":   "The avg function returns the average of all values taken by the arg1 expression in a group.",
 }
 
 var mathDocs = functionDocs{
+	"abs":   "Returns the absolute value of arg1.",
+	"acos":  "Returns the arcosine, in radiant, of arg1.",
+	"acosh": "Returns the inverse hyperbolic cosine of arg1.",
+	"asin":  "Returns the arsine, in radiant, of arg1.",
+	"asinh": "Returns the inverse hyperbolic sine of arg1.",
+	"atan":  "Returns the arctangent, in radians, of arg1.",
+	"atan2": "Returns the arctangent of arg1/arg2, using the signs of the two to determine the quadrant of the return value.",
 	"floor": "Returns the greatest integer value less than or equal to arg1.",
 }

--- a/internal/expr/functions/math.go
+++ b/internal/expr/functions/math.go
@@ -16,6 +16,11 @@ var mathFunctions = Definitions{
 	"floor": floor,
 	"abs":   abs,
 	"acos":  acos,
+	"acosh": acosh,
+	"asin":  asin,
+	"asinh": asinh,
+	"atan":  atan,
+	"atan2": atan2,
 }
 
 var floor = &ScalarDefinition{
@@ -80,5 +85,119 @@ var acos = &ScalarDefinition{
 		default:
 			return document.Value{}, stringutil.Errorf("acos(arg1) expects arg1 to be a number within [-1, 1]")
 		}
+	},
+}
+
+var acosh = &ScalarDefinition{
+	name:  "acosh",
+	arity: 1,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		switch args[0].Type {
+		case document.NullValue:
+			return document.NewNullValue(), nil
+		case document.IntegerValue:
+			v := args[0].V.(int64)
+			if v < 1 {
+				return document.Value{}, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
+			}
+			return document.NewDoubleValue(math.Acosh(float64(v))), nil
+		case document.DoubleValue:
+			v := args[0].V.(float64)
+			if v < 1.0 {
+				return document.Value{}, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
+			}
+			return document.NewDoubleValue(math.Acosh(v)), nil
+		default:
+			return document.Value{}, stringutil.Errorf("acosh(arg1) expects arg1 to be a number >= 1")
+		}
+	},
+}
+
+var asin = &ScalarDefinition{
+	name:  "asin",
+	arity: 1,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		switch args[0].Type {
+		case document.NullValue:
+			return document.NewNullValue(), nil
+		case document.IntegerValue:
+			v := args[0].V.(int64)
+			if v > 1 || v < -1 {
+				return document.Value{}, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
+			}
+			return document.NewDoubleValue(math.Asin(float64(v))), nil
+		case document.DoubleValue:
+			v := args[0].V.(float64)
+			if v > 1.0 || v < -1.0 {
+				return document.Value{}, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
+			}
+			return document.NewDoubleValue(math.Asin(v)), nil
+		default:
+			return document.Value{}, stringutil.Errorf("asin(arg1) expects arg1 to be a number within [-1, 1]")
+		}
+	},
+}
+
+var asinh = &ScalarDefinition{
+	name:  "asinh",
+	arity: 1,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		switch args[0].Type {
+		case document.NullValue:
+			return document.NewNullValue(), nil
+		case document.IntegerValue:
+			v := args[0].V.(int64)
+			return document.NewDoubleValue(math.Asinh(float64(v))), nil
+		case document.DoubleValue:
+			v := args[0].V.(float64)
+			return document.NewDoubleValue(math.Asinh(v)), nil
+		default:
+			return document.Value{}, stringutil.Errorf("asinh(arg1) expects arg1 to be a number")
+		}
+	},
+}
+
+var atan = &ScalarDefinition{
+	name:  "atan",
+	arity: 1,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		switch args[0].Type {
+		case document.NullValue:
+			return document.NewNullValue(), nil
+		case document.IntegerValue:
+			v := args[0].V.(int64)
+			return document.NewDoubleValue(math.Atan(float64(v))), nil
+		case document.DoubleValue:
+			v := args[0].V.(float64)
+			return document.NewDoubleValue(math.Atan(v)), nil
+		default:
+			return document.Value{}, stringutil.Errorf("atan(arg1) expects arg1 to be a number")
+		}
+	},
+}
+
+var atan2 = &ScalarDefinition{
+	name:  "atan2",
+	arity: 2,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		if args[0].Type == document.NullValue || args[1].Type == document.NullValue {
+			return document.NewNullValue(), nil
+		}
+		if !args[0].Type.IsNumber() || !args[1].Type.IsNumber() {
+			return document.Value{}, stringutil.Errorf("atan2(arg1, arg2) expects arg1 and arg2 to be numbers")
+		}
+
+		var a, b float64
+		if args[0].Type == document.IntegerValue {
+			a = float64(args[0].V.(int64))
+		} else {
+			a = args[0].V.(float64)
+		}
+		if args[1].Type == document.IntegerValue {
+			b = float64(args[1].V.(int64))
+		} else {
+			b = args[1].V.(float64)
+		}
+		return document.NewDoubleValue(math.Atan2(a, b)), nil
 	},
 }

--- a/internal/expr/functions/math.go
+++ b/internal/expr/functions/math.go
@@ -13,10 +13,12 @@ func MathFunctions() Definitions {
 }
 
 var mathFunctions = Definitions{
-	"floor": floorFunc,
+	"floor": floor,
+	"abs":   abs,
+	"acos":  acos,
 }
 
-var floorFunc = &ScalarDefinition{
+var floor = &ScalarDefinition{
 	name:  "floor",
 	arity: 1,
 	callFn: func(args ...types.Value) (types.Value, error) {
@@ -27,6 +29,56 @@ var floorFunc = &ScalarDefinition{
 			return args[0], nil
 		default:
 			return nil, stringutil.Errorf("floor(arg1) expects arg1 to be a number")
+		}
+	},
+}
+
+var abs = &ScalarDefinition{
+	name:  "abs",
+	arity: 1,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		switch args[0].Type {
+		case document.NullValue:
+			return document.NewNullValue(), nil
+		case document.IntegerValue:
+			v := args[0].V.(int64)
+			if v == math.MinInt64 {
+				// If X is the  integer -9223372036854775808 then abs(X) throws an integer overflow
+				// error since there is no equivalent positive 64-bit two complement value.
+				return document.Value{}, stringutil.Errorf("integer overflow")
+			}
+			f := math.Abs(float64(v))
+			return document.NewIntegerValue(int64(f)), nil
+		case document.DoubleValue:
+			v := args[0].V.(float64)
+			return document.NewDoubleValue(math.Abs(v)), nil
+		default:
+			return document.Value{}, stringutil.Errorf("abs(arg1) expects arg1 to be a number or NULL")
+		}
+	},
+}
+
+var acos = &ScalarDefinition{
+	name:  "acos",
+	arity: 1,
+	callFn: func(args ...document.Value) (document.Value, error) {
+		switch args[0].Type {
+		case document.NullValue:
+			return document.NewNullValue(), nil
+		case document.IntegerValue:
+			v := args[0].V.(int64)
+			if v > 1 || v < -1 {
+				return document.Value{}, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
+			}
+			return document.NewDoubleValue(math.Acos(float64(v))), nil
+		case document.DoubleValue:
+			v := args[0].V.(float64)
+			if v > 1.0 || v < -1.0 {
+				return document.Value{}, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
+			}
+			return document.NewDoubleValue(math.Acos(v)), nil
+		default:
+			return document.Value{}, stringutil.Errorf("acos(arg1) expects arg1 to be a number within [-1, 1]")
 		}
 	},
 }

--- a/internal/expr/functions/math.go
+++ b/internal/expr/functions/math.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"math"
 
+	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/internal/stringutil"
 	"github.com/genjidb/genji/types"
 )
@@ -41,125 +42,125 @@ var floor = &ScalarDefinition{
 var abs = &ScalarDefinition{
 	name:  "abs",
 	arity: 1,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		if args[0].Type == document.NullValue {
-			return document.NewNullValue(), nil
+	callFn: func(args ...types.Value) (types.Value, error) {
+		if args[0].Type() == types.NullValue {
+			return types.NewNullValue(), nil
 		}
-		v, err := args[0].CastAs(document.DoubleValue)
+		v, err := document.CastAs(args[0], types.DoubleValue)
 		if err != nil {
-			return document.Value{}, err
+			return nil, err
 		}
-		res := math.Abs(v.V.(float64))
-		if args[0].Type == document.IntegerValue {
-			return document.NewDoubleValue(res).CastAsInteger()
+		res := math.Abs(v.V().(float64))
+		if args[0].Type() == types.IntegerValue {
+			return document.CastAs(types.NewDoubleValue(res), types.IntegerValue)
 		}
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }
 
 var acos = &ScalarDefinition{
 	name:  "acos",
 	arity: 1,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		if args[0].Type == document.NullValue {
-			return document.NewNullValue(), nil
+	callFn: func(args ...types.Value) (types.Value, error) {
+		if args[0].Type() == types.NullValue {
+			return types.NewNullValue(), nil
 		}
-		v, err := args[0].CastAs(document.DoubleValue)
+		v, err := document.CastAs(args[0], types.DoubleValue)
 		if err != nil {
-			return document.Value{}, err
+			return nil, err
 		}
-		vv := v.V.(float64)
+		vv := v.V().(float64)
 		if vv > 1.0 || vv < -1.0 {
-			return document.Value{}, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
+			return nil, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
 		}
 		res := math.Acos(vv)
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }
 
 var acosh = &ScalarDefinition{
 	name:  "acosh",
 	arity: 1,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		if args[0].Type == document.NullValue {
-			return document.NewNullValue(), nil
+	callFn: func(args ...types.Value) (types.Value, error) {
+		if args[0].Type() == types.NullValue {
+			return types.NewNullValue(), nil
 		}
-		v, err := args[0].CastAs(document.DoubleValue)
+		v, err := document.CastAs(args[0], types.DoubleValue)
 		if err != nil {
-			return document.Value{}, err
+			return nil, err
 		}
-		vv := v.V.(float64)
+		vv := v.V().(float64)
 		if vv < 1.0 {
-			return document.Value{}, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
+			return nil, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
 		}
 		res := math.Acosh(vv)
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }
 
 var asin = &ScalarDefinition{
 	name:  "asin",
 	arity: 1,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		if args[0].Type == document.NullValue {
-			return document.NewNullValue(), nil
+	callFn: func(args ...types.Value) (types.Value, error) {
+		if args[0].Type() == types.NullValue {
+			return types.NewNullValue(), nil
 		}
-		v, err := args[0].CastAs(document.DoubleValue)
+		v, err := document.CastAs(args[0], types.DoubleValue)
 		if err != nil {
-			return document.Value{}, err
+			return nil, err
 		}
-		vv := v.V.(float64)
+		vv := v.V().(float64)
 		if vv > 1.0 || vv < -1.0 {
-			return document.Value{}, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
+			return nil, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
 		}
 		res := math.Asin(vv)
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }
 
 var asinh = &ScalarDefinition{
 	name:  "asinh",
 	arity: 1,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		v, err := args[0].CastAs(document.DoubleValue)
-		if err != nil || v.Type == document.NullValue {
+	callFn: func(args ...types.Value) (types.Value, error) {
+		v, err := document.CastAs(args[0], types.DoubleValue)
+		if err != nil || v.Type() == types.NullValue {
 			return v, err
 		}
-		vv := v.V.(float64)
+		vv := v.V().(float64)
 		res := math.Asinh(vv)
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }
 
 var atan = &ScalarDefinition{
 	name:  "atan",
 	arity: 1,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		v, err := args[0].CastAs(document.DoubleValue)
-		if err != nil || v.Type == document.NullValue {
+	callFn: func(args ...types.Value) (types.Value, error) {
+		v, err := document.CastAs(args[0], types.DoubleValue)
+		if err != nil || v.Type() == types.NullValue {
 			return v, err
 		}
-		vv := v.V.(float64)
+		vv := v.V().(float64)
 		res := math.Atan(vv)
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }
 
 var atan2 = &ScalarDefinition{
 	name:  "atan2",
 	arity: 2,
-	callFn: func(args ...document.Value) (document.Value, error) {
-		vA, err := args[0].CastAs(document.DoubleValue)
-		if err != nil || vA.Type == document.NullValue {
+	callFn: func(args ...types.Value) (types.Value, error) {
+		vA, err := document.CastAs(args[0], types.DoubleValue)
+		if err != nil || vA.Type() == types.NullValue {
 			return vA, err
 		}
-		vvA := vA.V.(float64)
-		vB, err := args[1].CastAs(document.DoubleValue)
-		if err != nil || vB.Type == document.NullValue {
+		vvA := vA.V().(float64)
+		vB, err := document.CastAs(args[1], types.DoubleValue)
+		if err != nil || vB.Type() == types.NullValue {
 			return vB, err
 		}
-		vvB := vB.V.(float64)
+		vvB := vB.V().(float64)
 		res := math.Atan2(vvA, vvB)
-		return document.NewDoubleValue(res), nil
+		return types.NewDoubleValue(res), nil
 	},
 }

--- a/internal/expr/functions/math.go
+++ b/internal/expr/functions/math.go
@@ -42,24 +42,18 @@ var abs = &ScalarDefinition{
 	name:  "abs",
 	arity: 1,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		switch args[0].Type {
-		case document.NullValue:
+		if args[0].Type == document.NullValue {
 			return document.NewNullValue(), nil
-		case document.IntegerValue:
-			v := args[0].V.(int64)
-			if v == math.MinInt64 {
-				// If X is the  integer -9223372036854775808 then abs(X) throws an integer overflow
-				// error since there is no equivalent positive 64-bit two complement value.
-				return document.Value{}, stringutil.Errorf("integer overflow")
-			}
-			f := math.Abs(float64(v))
-			return document.NewIntegerValue(int64(f)), nil
-		case document.DoubleValue:
-			v := args[0].V.(float64)
-			return document.NewDoubleValue(math.Abs(v)), nil
-		default:
-			return document.Value{}, stringutil.Errorf("abs(arg1) expects arg1 to be a number or NULL")
 		}
+		v, err := args[0].CastAs(document.DoubleValue)
+		if err != nil {
+			return document.Value{}, err
+		}
+		res := math.Abs(v.V.(float64))
+		if args[0].Type == document.IntegerValue {
+			return document.NewDoubleValue(res).CastAsInteger()
+		}
+		return document.NewDoubleValue(res), nil
 	},
 }
 
@@ -67,24 +61,19 @@ var acos = &ScalarDefinition{
 	name:  "acos",
 	arity: 1,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		switch args[0].Type {
-		case document.NullValue:
+		if args[0].Type == document.NullValue {
 			return document.NewNullValue(), nil
-		case document.IntegerValue:
-			v := args[0].V.(int64)
-			if v > 1 || v < -1 {
-				return document.Value{}, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
-			}
-			return document.NewDoubleValue(math.Acos(float64(v))), nil
-		case document.DoubleValue:
-			v := args[0].V.(float64)
-			if v > 1.0 || v < -1.0 {
-				return document.Value{}, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
-			}
-			return document.NewDoubleValue(math.Acos(v)), nil
-		default:
-			return document.Value{}, stringutil.Errorf("acos(arg1) expects arg1 to be a number within [-1, 1]")
 		}
+		v, err := args[0].CastAs(document.DoubleValue)
+		if err != nil {
+			return document.Value{}, err
+		}
+		vv := v.V.(float64)
+		if vv > 1.0 || vv < -1.0 {
+			return document.Value{}, stringutil.Errorf("out of range, acos(arg1) expects arg1 to be within [-1, 1]")
+		}
+		res := math.Acos(vv)
+		return document.NewDoubleValue(res), nil
 	},
 }
 
@@ -92,24 +81,19 @@ var acosh = &ScalarDefinition{
 	name:  "acosh",
 	arity: 1,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		switch args[0].Type {
-		case document.NullValue:
+		if args[0].Type == document.NullValue {
 			return document.NewNullValue(), nil
-		case document.IntegerValue:
-			v := args[0].V.(int64)
-			if v < 1 {
-				return document.Value{}, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
-			}
-			return document.NewDoubleValue(math.Acosh(float64(v))), nil
-		case document.DoubleValue:
-			v := args[0].V.(float64)
-			if v < 1.0 {
-				return document.Value{}, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
-			}
-			return document.NewDoubleValue(math.Acosh(v)), nil
-		default:
-			return document.Value{}, stringutil.Errorf("acosh(arg1) expects arg1 to be a number >= 1")
 		}
+		v, err := args[0].CastAs(document.DoubleValue)
+		if err != nil {
+			return document.Value{}, err
+		}
+		vv := v.V.(float64)
+		if vv < 1.0 {
+			return document.Value{}, stringutil.Errorf("out of range, acosh(arg1) expects arg1 >= 1")
+		}
+		res := math.Acosh(vv)
+		return document.NewDoubleValue(res), nil
 	},
 }
 
@@ -117,24 +101,19 @@ var asin = &ScalarDefinition{
 	name:  "asin",
 	arity: 1,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		switch args[0].Type {
-		case document.NullValue:
+		if args[0].Type == document.NullValue {
 			return document.NewNullValue(), nil
-		case document.IntegerValue:
-			v := args[0].V.(int64)
-			if v > 1 || v < -1 {
-				return document.Value{}, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
-			}
-			return document.NewDoubleValue(math.Asin(float64(v))), nil
-		case document.DoubleValue:
-			v := args[0].V.(float64)
-			if v > 1.0 || v < -1.0 {
-				return document.Value{}, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
-			}
-			return document.NewDoubleValue(math.Asin(v)), nil
-		default:
-			return document.Value{}, stringutil.Errorf("asin(arg1) expects arg1 to be a number within [-1, 1]")
 		}
+		v, err := args[0].CastAs(document.DoubleValue)
+		if err != nil {
+			return document.Value{}, err
+		}
+		vv := v.V.(float64)
+		if vv > 1.0 || vv < -1.0 {
+			return document.Value{}, stringutil.Errorf("out of range, asin(arg1) expects arg1 to be within [-1, 1]")
+		}
+		res := math.Asin(vv)
+		return document.NewDoubleValue(res), nil
 	},
 }
 
@@ -142,18 +121,13 @@ var asinh = &ScalarDefinition{
 	name:  "asinh",
 	arity: 1,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		switch args[0].Type {
-		case document.NullValue:
-			return document.NewNullValue(), nil
-		case document.IntegerValue:
-			v := args[0].V.(int64)
-			return document.NewDoubleValue(math.Asinh(float64(v))), nil
-		case document.DoubleValue:
-			v := args[0].V.(float64)
-			return document.NewDoubleValue(math.Asinh(v)), nil
-		default:
-			return document.Value{}, stringutil.Errorf("asinh(arg1) expects arg1 to be a number")
+		v, err := args[0].CastAs(document.DoubleValue)
+		if err != nil || v.Type == document.NullValue {
+			return v, err
 		}
+		vv := v.V.(float64)
+		res := math.Asinh(vv)
+		return document.NewDoubleValue(res), nil
 	},
 }
 
@@ -161,18 +135,13 @@ var atan = &ScalarDefinition{
 	name:  "atan",
 	arity: 1,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		switch args[0].Type {
-		case document.NullValue:
-			return document.NewNullValue(), nil
-		case document.IntegerValue:
-			v := args[0].V.(int64)
-			return document.NewDoubleValue(math.Atan(float64(v))), nil
-		case document.DoubleValue:
-			v := args[0].V.(float64)
-			return document.NewDoubleValue(math.Atan(v)), nil
-		default:
-			return document.Value{}, stringutil.Errorf("atan(arg1) expects arg1 to be a number")
+		v, err := args[0].CastAs(document.DoubleValue)
+		if err != nil || v.Type == document.NullValue {
+			return v, err
 		}
+		vv := v.V.(float64)
+		res := math.Atan(vv)
+		return document.NewDoubleValue(res), nil
 	},
 }
 
@@ -180,24 +149,17 @@ var atan2 = &ScalarDefinition{
 	name:  "atan2",
 	arity: 2,
 	callFn: func(args ...document.Value) (document.Value, error) {
-		if args[0].Type == document.NullValue || args[1].Type == document.NullValue {
-			return document.NewNullValue(), nil
+		vA, err := args[0].CastAs(document.DoubleValue)
+		if err != nil || vA.Type == document.NullValue {
+			return vA, err
 		}
-		if !args[0].Type.IsNumber() || !args[1].Type.IsNumber() {
-			return document.Value{}, stringutil.Errorf("atan2(arg1, arg2) expects arg1 and arg2 to be numbers")
+		vvA := vA.V.(float64)
+		vB, err := args[1].CastAs(document.DoubleValue)
+		if err != nil || vB.Type == document.NullValue {
+			return vB, err
 		}
-
-		var a, b float64
-		if args[0].Type == document.IntegerValue {
-			a = float64(args[0].V.(int64))
-		} else {
-			a = args[0].V.(float64)
-		}
-		if args[1].Type == document.IntegerValue {
-			b = float64(args[1].V.(int64))
-		} else {
-			b = args[1].V.(float64)
-		}
-		return document.NewDoubleValue(math.Atan2(a, b)), nil
+		vvB := vB.V.(float64)
+		res := math.Atan2(vvA, vvB)
+		return document.NewDoubleValue(res), nil
 	},
 }

--- a/internal/expr/functions/testdata/math_functions.sql
+++ b/internal/expr/functions/testdata/math_functions.sql
@@ -19,6 +19,8 @@ NULL
 'abs(arg1) expects arg1 to be a number'
 
 -- test: math.acos
+> math.acos(NULL)
+NULL
 > math.acos(1)
 0.0
 > math.acos(0.5)
@@ -33,3 +35,83 @@ NULL
 'out of range'
 ! math.acos('foobar')
 'acos(arg1) expects arg1 to be a number'
+
+-- test: math.acosh
+> math.acosh(NULL)
+NULL
+> math.acosh(1)
+0.0
+> math.acosh(2)
+1.3169578969248166
+> math.acosh(2.5)
+1.566799236972411
+! math.acosh(0)
+'out of range'
+! math.acosh(0.99999999)
+'out of range'
+! math.acosh('foobar')
+'acosh(arg1) expects arg1 to be a number'
+
+-- test: math.asin
+> math.asin(NULL)
+NULL
+> math.asin(0)
+0.0
+> math.asin(0.5)
+0.5235987755982989
+! math.asin(2)
+'out of range'
+! math.asin(-2)
+'out of range'
+! math.asin(2.2)
+'out of range'
+! math.asin(-2.2)
+'out of range'
+! math.asin('foobar')
+'asin(arg1) expects arg1 to be a number'
+
+-- test: math.asinh
+> math.asinh(NULL)
+NULL
+> math.asinh(0)
+0.0
+> math.asinh(0.5)
+0.48121182505960347
+> math.asinh(1)
+0.881373587019543
+> math.asinh(-1)
+-0.881373587019543
+! math.asinh('foobar')
+'asinh(arg1) expects arg1 to be a number'
+
+-- test: math.atan
+> math.atan(NULL)
+NULL
+> math.atan(0)
+0.0
+> math.atan(0.5)
+0.4636476090008061
+> math.atan(1)
+0.7853981633974483
+> math.atan(-1)
+-0.7853981633974483
+! math.atan('foobar')
+'atan(arg1) expects arg1 to be a number'
+
+-- test: math.atan2
+> math.atan2(NULL, NULL)
+NULL
+> math.atan2(1, NULL)
+NULL
+> math.atan2(NULL, 1)
+NULL
+> math.atan2(0, 0)
+0.0
+> math.atan2(1, 1)
+0.7853981633974483
+> math.atan2(1.1, 1.1)
+0.7853981633974483
+> math.atan2(1.1, -1.1)
+2.356194490192345
+! math.atan2('foobar', 1)
+'atan2(arg1, arg2) expects arg1 and arg2 to be numbers'

--- a/internal/expr/functions/testdata/math_functions.sql
+++ b/internal/expr/functions/testdata/math_functions.sql
@@ -1,9 +1,35 @@
 -- test: math.floor
 > math.floor(2.3)
 2.0
-
 > math.floor(2)
 2
-
 ! math.floor('a')
 'floor(arg1) expects arg1 to be a number'
+
+-- test: math.abs
+> math.abs(NULL)
+NULL
+> math.abs(-2)
+2
+> math.abs(-2.0)
+2.0
+! math.abs(-9223372036854775808)
+'integer overflow'
+! math.abs('foo')
+'abs(arg1) expects arg1 to be a number'
+
+-- test: math.acos
+> math.acos(1)
+0.0
+> math.acos(0.5)
+1.0471975511965976
+! math.acos(2)
+'out of range'
+! math.acos(-2)
+'out of range'
+! math.acos(2.2)
+'out of range'
+! math.acos(-2.2)
+'out of range'
+! math.acos('foobar')
+'acos(arg1) expects arg1 to be a number'

--- a/internal/expr/functions/testdata/math_functions.sql
+++ b/internal/expr/functions/testdata/math_functions.sql
@@ -13,10 +13,10 @@ NULL
 2
 > math.abs(-2.0)
 2.0
-! math.abs(-9223372036854775808)
-'integer overflow'
+> math.abs('-2.0')
+2.0
 ! math.abs('foo')
-'abs(arg1) expects arg1 to be a number'
+'cannot cast "foo" as double'
 
 -- test: math.acos
 > math.acos(NULL)
@@ -24,6 +24,8 @@ NULL
 > math.acos(1)
 0.0
 > math.acos(0.5)
+1.0471975511965976
+> math.acos('0.5')
 1.0471975511965976
 ! math.acos(2)
 'out of range'
@@ -33,8 +35,8 @@ NULL
 'out of range'
 ! math.acos(-2.2)
 'out of range'
-! math.acos('foobar')
-'acos(arg1) expects arg1 to be a number'
+! math.acos('foo')
+'cannot cast "foo" as double'
 
 -- test: math.acosh
 > math.acosh(NULL)
@@ -43,14 +45,16 @@ NULL
 0.0
 > math.acosh(2)
 1.3169578969248166
+> math.acosh('2')
+1.3169578969248166
 > math.acosh(2.5)
 1.566799236972411
 ! math.acosh(0)
 'out of range'
 ! math.acosh(0.99999999)
 'out of range'
-! math.acosh('foobar')
-'acosh(arg1) expects arg1 to be a number'
+! math.acosh('foo')
+'cannot cast "foo" as double'
 
 -- test: math.asin
 > math.asin(NULL)
@@ -67,8 +71,8 @@ NULL
 'out of range'
 ! math.asin(-2.2)
 'out of range'
-! math.asin('foobar')
-'asin(arg1) expects arg1 to be a number'
+! math.asin('foo')
+'cannot cast "foo" as double'
 
 -- test: math.asinh
 > math.asinh(NULL)
@@ -81,8 +85,8 @@ NULL
 0.881373587019543
 > math.asinh(-1)
 -0.881373587019543
-! math.asinh('foobar')
-'asinh(arg1) expects arg1 to be a number'
+! math.asinh('foo')
+'cannot cast "foo" as double'
 
 -- test: math.atan
 > math.atan(NULL)
@@ -95,8 +99,8 @@ NULL
 0.7853981633974483
 > math.atan(-1)
 -0.7853981633974483
-! math.atan('foobar')
-'atan(arg1) expects arg1 to be a number'
+! math.atan('foo')
+'cannot cast "foo" as double'
 
 -- test: math.atan2
 > math.atan2(NULL, NULL)
@@ -113,5 +117,5 @@ NULL
 0.7853981633974483
 > math.atan2(1.1, -1.1)
 2.356194490192345
-! math.atan2('foobar', 1)
-'atan2(arg1, arg2) expects arg1 and arg2 to be numbers'
+! math.atan2('foo', 1)
+'cannot cast "foo" as double'


### PR DESCRIPTION
See this spreadsheet for following progress on functions implementations: 

https://docs.google.com/spreadsheets/d/e/2PACX-1vQeXU_3ymhCOYL5mkeOVObTFhTuF6CNUogDXN-1sDn7Kb55GZtSJDquJw5PyX7JS_x0cLZCoxtou4AA/pubhtml

@asdine I think it's worth going step by step on those, taking the time to think about some decisions as we go through 👇 

In the context of those functions, I think we need to agree on: 

- Genji's function explicitly deal with their input validation, so we can produce readable error messages. Those are a part of the API after all. 
- Most of the mathematical functions are returning `NULL` when some arg is `NULL`. That's what PG / SQLite does, I see no reason from deviating from it.
- Functions that accept floats can take in integers, implicitly. Same as the above. 


