### PR TITLE
Improve failures readability when testing exprs

### DIFF
--- a/internal/testutil/genexprtests/genexprtests.go
+++ b/internal/testutil/genexprtests/genexprtests.go
@@ -8,9 +8,11 @@ import (
 )
 
 type statement struct {
-	Expr string
-	Res  string
-	Fail bool
+	Expr     string
+	ExprLine int
+	Res      string
+	ResLine  int
+	Fail     bool
 }
 
 type test struct {
@@ -28,9 +30,10 @@ func Parse(r io.Reader) (*testSuite, error) {
 
 	var curTest *test
 	var curStmt *statement
+	lineNum := 0
 	for s.Scan() {
 		line := strings.TrimSpace(s.Text())
-
+		lineNum++
 		switch {
 		case line == "":
 			continue
@@ -45,14 +48,16 @@ func Parse(r io.Reader) (*testSuite, error) {
 		case line[0] == '>':
 			text := strings.TrimPrefix(line, "> ")
 			curStmt = &statement{
-				Expr: text,
+				Expr:     text,
+				ExprLine: lineNum,
 			}
 			curTest.Statements = append(curTest.Statements, curStmt)
 		case line[0] == '!':
 			text := strings.TrimPrefix(line, "! ")
 			curStmt = &statement{
-				Expr: text,
-				Fail: true,
+				Expr:     text,
+				ExprLine: lineNum,
+				Fail:     true,
 			}
 			curTest.Statements = append(curTest.Statements, curStmt)
 		default:
@@ -65,6 +70,7 @@ func Parse(r io.Reader) (*testSuite, error) {
 			} else {
 				curStmt.Res = line
 			}
+			curStmt.ResLine = lineNum
 		}
 	}
 


### PR DESCRIPTION
With a bunch of `t.Helpers()` and line numbering, it's now much better. Because the originating file path (the sql) is absolute, you can click on it within your editor to open it (ignore the truncated version in the example below, it's a proper path in the code). 

```
--- FAIL: TestMathFunctions (0.00s)
    --- FAIL: TestMathFunctions/math.floor (0.00s)
        --- FAIL: TestMathFunctions/math.floor/OK_@#math.floor(2.3) (0.00s)
            math_test.go:11:
                        Error Trace:    expr.go:160
                        Error:          Received unexpected error:
                                        found @, expected  at line 1, char 1
                        Test:           TestMathFunctions/math.floor/OK_@#math.floor(2.3)
                        Messages:       parse error at (/home/...)/testdata/math_functions.sql:2
                                        `@#math.floor(2.3)`
    --- FAIL: TestMathFunctions/math.abs (0.00s)
        --- FAIL: TestMathFunctions/math.abs/NOK_math.abs('foo') (0.00s)
            math_test.go:11:
                        Error Trace:    expr.go:180
                        Error:          Expect "cannot cast "foo" as double: strconv.ParseFloat: parsing "foo": invalid syntax" to match "cwfpwannot cast "foo" as double"
                        Test:           TestMathFunctions/math.abs/NOK_math.abs('foo')
                        Messages:       expected error message to match at (/home/...)/testdata/math_functions.sql:19
```