### PR TITLE
update installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Checkout the [SQL documentation](https://genji.dev/docs/genji-sql), the [Go doc]
 Install the Genji database
 
 ```bash
-go get github.com/genjidb/genji
+go install github.com/genjidb/genji/cmd/genji@latest
 ```
 
 ## Usage
@@ -206,7 +206,7 @@ The genji command line provides an SQL shell that can be used to create, modify 
 Make sure the Genji command line is installed:
 
 ```bash
-go get github.com/genjidb/genji/cmd/genji
+go install github.com/genjidb/genji/cmd/genji@latest
 ```
 
 Example:


### PR DESCRIPTION
Starting in Go 1.17, installing executables with `go get` is deprecated and `go install` is preferred. Version suffix is used to let users run this command outside the module directory which makes installation of genji more universal.

I just tried to install `genji` myself and bumped into an error. Fixed commands worked fine.