### PR TITLE
add .restore command

### DIFF
--- a/cmd/genji/commands/restore.go
+++ b/cmd/genji/commands/restore.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
-	"os"
-
 	"github.com/cockroachdb/errors"
 	"github.com/genjidb/genji/cmd/genji/dbutil"
 	"github.com/urfave/cli/v2"
@@ -20,32 +17,11 @@ func NewRestoreCommand() (cmd *cli.Command) {
 	$ genji restore dump.sql mydb`,
 		Flags: []cli.Flag{},
 		Action: func(c *cli.Context) error {
-			if c.Args().Len() != 2 {
+			args := c.Args()
+			if args.Len() != 2 {
 				return errors.New(cmd.UsageText)
 			}
-			dbPath := c.Args().Get(c.Args().Len() - 1)
-			if dbPath == "" {
-				return errors.New("database path expected")
-			}
-
-			f := c.Args().First()
-			if f == "" {
-				return errors.New("dump file expected")
-			}
-
-			file, err := os.Open(f)
-			if err != nil {
-				return err
-			}
-			defer file.Close()
-
-			db, err := dbutil.OpenDB(c.Context, dbPath)
-			if err != nil {
-				return err
-			}
-			defer db.Close()
-
-			return dbutil.ExecSQL(c.Context, db, file, ioutil.Discard)
+			return dbutil.Restore(c.Context, nil, args.First(), args.Get(args.Len()-1))
 		},
 	}
 }

--- a/cmd/genji/dbutil/restore.go
+++ b/cmd/genji/dbutil/restore.go
@@ -1,0 +1,39 @@
+package dbutil
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	"github.com/cockroachdb/errors"
+	"github.com/genjidb/genji"
+)
+
+// Restore a database from a file created by genji dump.
+// This function can be provided with an existing database (genji cli use case),
+// otherwise new database is being created.
+func Restore(ctx context.Context, db *genji.DB, dumpFile, dbPath string) error {
+	if dbPath == "" {
+		return errors.New("database path expected")
+	}
+
+	if dumpFile == "" {
+		return errors.New("dump file expected")
+	}
+
+	file, err := os.Open(dumpFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if db == nil {
+		db, err = OpenDB(ctx, dbPath)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+	}
+
+	return ExecSQL(ctx, db, file, ioutil.Discard)
+}

--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -91,6 +91,12 @@ var commands = []command{
 		DisplayName: ".timer",
 		Description: "Display the execution time after each query or hide it.",
 	},
+	{
+		Name:        ".restore",
+		Options:     "[dumpFile]",
+		DisplayName: ".restore",
+		Description: "The restore command can restore a database from a text file.",
+	},
 }
 
 func getUsage(cmdName string) string {
@@ -145,7 +151,7 @@ func runTablesCmd(db *genji.DB, w io.Writer) error {
 }
 
 // runIndexesCmd displays a list of indexes. If table is non-empty, it only
-// display that table's indexes. If not, it displays all indexes.
+// displays that table's indexes. If not, it displays all indexes.
 func runIndexesCmd(db *genji.DB, tableName string, w io.Writer) error {
 	// ensure table exists
 	if tableName != "" {

--- a/cmd/genji/shell/shell.go
+++ b/cmd/genji/shell/shell.go
@@ -464,14 +464,10 @@ func (sh *Shell) runCommand(ctx context.Context, in string) error {
 	case ".dump":
 		return dbutil.Dump(sh.db, os.Stdout, cmd[1:]...)
 	case ".save":
-		var path string
-		if len(cmd) == 2 {
-			path = cmd[1]
-		} else {
-			return fmt.Errorf("can't save without output path")
+		if len(cmd) != 2 {
+			return fmt.Errorf("cannot save without output path")
 		}
-
-		return runSaveCmd(ctx, sh.db, path)
+		return runSaveCmd(ctx, sh.db, cmd[1])
 	case ".schema":
 		return dbutil.DumpSchema(sh.db, os.Stdout, cmd[1:]...)
 	case ".import":
@@ -485,6 +481,11 @@ func (sh *Shell) runCommand(ctx context.Context, in string) error {
 			return fmt.Errorf(getUsage(".doc"))
 		}
 		return runDocCmd(cmd[1])
+	case ".restore":
+		if len(cmd) != 2 {
+			return fmt.Errorf(getUsage(".restore"))
+		}
+		return dbutil.Restore(ctx, sh.db, cmd[1], "./")
 	default:
 		return displaySuggestions(in)
 	}


### PR DESCRIPTION
Restore command works exactly like `genji restore` ~and restarts the shell to open the database which was restored from the dump.~ and applies given dump to currently open database

~@asdine I also thought about adding a flag to decide whether:~
~1) we want to restart the shell and go to restored database~
~or~
~2) stay in current database.~

~But probably I am trying to overthink this and option 1 (which is currently implemented) is fine~