### PR TITLE
remove unused contexts from cmd/genji

### DIFF
--- a/cmd/genji/commands/bench.go
+++ b/cmd/genji/commands/bench.go
@@ -96,7 +96,7 @@ in the same transaction, use -t`,
 		}
 		defer db.Close()
 
-		return dbutil.Bench(c.Context, db, query, dbutil.BenchOptions{
+		return dbutil.Bench(db, query, dbutil.BenchOptions{
 			Init:       c.String("init"),
 			N:          c.Int("number"),
 			SampleSize: c.Int("sample"),

--- a/cmd/genji/commands/dump.go
+++ b/cmd/genji/commands/dump.go
@@ -70,7 +70,7 @@ $ genji dump -f dump.sql my.db`,
 			w = file
 		}
 
-		return dbutil.Dump(c.Context, db, w, tables...)
+		return dbutil.Dump(db, w, tables...)
 	}
 
 	return &cmd

--- a/cmd/genji/dbutil/bench.go
+++ b/cmd/genji/dbutil/bench.go
@@ -1,7 +1,6 @@
 package dbutil
 
 import (
-	"context"
 	"encoding/csv"
 	"encoding/json"
 	"io"
@@ -30,7 +29,7 @@ type execer func(q string, args ...interface{}) error
 
 // Bench takes a database and dumps its content as SQL queries in the given writer.
 // If tables is provided, only selected tables will be outputted.
-func Bench(ctx context.Context, db *genji.DB, query string, opt BenchOptions) error {
+func Bench(db *genji.DB, query string, opt BenchOptions) error {
 	var p preparer = db
 	var e execer = db.Exec
 

--- a/cmd/genji/dbutil/dump.go
+++ b/cmd/genji/dbutil/dump.go
@@ -1,7 +1,6 @@
 package dbutil
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -13,7 +12,7 @@ import (
 
 // Dump takes a database and dumps its content as SQL queries in the given writer.
 // If tables is provided, only selected tables will be outputted.
-func Dump(ctx context.Context, db *genji.DB, w io.Writer, tables ...string) error {
+func Dump(db *genji.DB, w io.Writer, tables ...string) error {
 	tx, err := db.Begin(false)
 	if err != nil {
 		return err
@@ -77,7 +76,7 @@ func dumpTable(tx *genji.Tx, w io.Writer, query, tableName string) error {
 
 // DumpSchema takes a database and dumps its schema as SQL queries in the given writer.
 // If tables are provided, only selected tables will be outputted.
-func DumpSchema(ctx context.Context, db *genji.DB, w io.Writer, tables ...string) error {
+func DumpSchema(db *genji.DB, w io.Writer, tables ...string) error {
 	tx, err := db.Begin(false)
 	if err != nil {
 		return err

--- a/cmd/genji/dbutil/dump_test.go
+++ b/cmd/genji/dbutil/dump_test.go
@@ -2,7 +2,6 @@ package dbutil
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"testing"
 
@@ -87,7 +86,7 @@ func TestDump(t *testing.T) {
 			want.WriteString("COMMIT;\n")
 
 			var got bytes.Buffer
-			err = Dump(context.Background(), db, &got, tt.tables...)
+			err = Dump(db, &got, tt.tables...)
 			assert.NoError(t, err)
 
 			require.Equal(t, want.String(), got.String())

--- a/cmd/genji/dbutil/schema.go
+++ b/cmd/genji/dbutil/schema.go
@@ -1,8 +1,6 @@
 package dbutil
 
 import (
-	"context"
-
 	"github.com/genjidb/genji"
 	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/internal/query/statement"
@@ -33,7 +31,7 @@ func QueryTables(tx *genji.Tx, tables []string, fn func(name, query string) erro
 	})
 }
 
-func ListIndexes(ctx context.Context, db *genji.DB, tableName string) ([]string, error) {
+func ListIndexes(db *genji.DB, tableName string) ([]string, error) {
 	var listName []string
 	q := "SELECT sql FROM __genji_catalog WHERE type = 'index'"
 	if tableName != "" {

--- a/cmd/genji/shell/command.go
+++ b/cmd/genji/shell/command.go
@@ -158,7 +158,7 @@ func runIndexesCmd(db *genji.DB, tableName string, w io.Writer) error {
 		}
 	}
 
-	indexes, err := dbutil.ListIndexes(context.Background(), db, tableName)
+	indexes, err := dbutil.ListIndexes(db, tableName)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func runSaveCmd(ctx context.Context, db *genji.DB, dbPath string) error {
 
 	var dbDump bytes.Buffer
 
-	err = dbutil.Dump(ctx, db, &dbDump)
+	err = dbutil.Dump(db, &dbDump)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func runSaveCmd(ctx context.Context, db *genji.DB, dbPath string) error {
 	return otherDB.Exec(dbDump.String())
 }
 
-func runImportCmd(ctx context.Context, db *genji.DB, fileType, path, table string) error {
+func runImportCmd(db *genji.DB, fileType, path, table string) error {
 	if strings.ToLower(fileType) != "csv" {
 		return errors.New("TYPE should be csv")
 	}

--- a/cmd/genji/shell/command_test.go
+++ b/cmd/genji/shell/command_test.go
@@ -135,7 +135,7 @@ func TestSaveCommand(t *testing.T) {
 	require.Equal(t, 2, res.B)
 
 	// ensure that the index has been created
-	indexes, err := dbutil.ListIndexes(context.Background(), db, "")
+	indexes, err := dbutil.ListIndexes(db, "")
 	assert.NoError(t, err)
 	require.Len(t, indexes, 1)
 	require.Equal(t, "idx_a_b", indexes[0])


### PR DESCRIPTION
Just a cleanup of unused `context.Context` input parameters