### PR TITLE
orderby: fix evaluation of ORDER BY expr when used with projection

### DIFF
--- a/sqltests/SELECT/order_by.sql
+++ b/sqltests/SELECT/order_by.sql
@@ -1,6 +1,6 @@
 -- setup:
-CREATE TABLE test(a double);
-INSERT INTO test (a) VALUES (1), (2), (3);
+CREATE TABLE test(a double, b double);
+INSERT INTO test (a, b) VALUES (50, 3), (100, 4), (10, 2), (null, 1);
 
 -- suite: no index
 
@@ -8,30 +8,77 @@ INSERT INTO test (a) VALUES (1), (2), (3);
 CREATE INDEX ON test(a);
 
 -- test: asc
+SELECT b FROM test ORDER BY a;
+/* result:
+{
+    b: 1.0,
+}
+{
+    b: 2.0
+}
+{
+    b: 3.0
+}
+{
+    b: 4.0
+}
+*/
+
+
+-- test: asc / wildcard
 SELECT * FROM test ORDER BY a;
 /* result:
 {
-    a: 1.0
+    b: 1.0,
 }
 {
-    a: 2.0
+    a: 10.0,
+    b: 2.0
 }
 {
-    a: 3.0
+    a: 50.0,
+    b: 3.0
+}
+{
+    a: 100.0,
+    b: 4.0
 }
 */
 
+
 -- test: desc
+SELECT b FROM test ORDER BY a DESC;
+/* result:
+{
+    b: 4.0,
+}
+{
+    b: 3.0
+}
+{
+    b: 2.0
+}
+{
+    b: 1.0
+}
+*/
+
+-- test: desc / wildcard
 SELECT * FROM test ORDER BY a DESC;
 /* result:
 {
-    a: 3.0
+    a: 100.0,
+    b: 4.0,
 }
 {
-    a: 2.0
+    a: 50.0,
+    b: 3.0
 }
 {
-    a: 1.0
+    a: 10.0,
+    b: 2.0
+}
+{
+    b: 1.0
 }
 */
-

--- a/types/value.go
+++ b/types/value.go
@@ -124,6 +124,10 @@ func Is[T any](v Value) (T, bool) {
 	return vv.v, true
 }
 
+func IsNull(v Value) bool {
+	return v == nil || v.Type() == NullValue
+}
+
 // IsTruthy returns whether v is not equal to the zero value of its type.
 func IsTruthy(v Value) (bool, error) {
 	if v.Type() == NullValue {


### PR DESCRIPTION
When the ORDER BY expression uses fields that are not present in the preceding projection operator,
it was evaluating the expression to NULL, which was breaking the ordering.
It now evaluates the expr against the result of the projection first, then if it is NULL
evaluates it against the original document.

Example:
```bash
table.Scan("test") | docs.Project(b) | docs.TempTreeSort(a)
```

Fixes #466