### PR TITLE
Add LEN builtin function

### DIFF
--- a/cmd/genji/doc/functions.go
+++ b/cmd/genji/doc/functions.go
@@ -15,6 +15,7 @@ var builtinDocs = functionDocs{
 	"sum":    "The sum function returns the sum of all values taken by the arg1 expression in a group.",
 	"avg":    "The avg function returns the average of all values taken by the arg1 expression in a group.",
 	"typeof": "The typeof function returns the type of arg1.",
+	"len":    "Then len function returns length of the arg1 expression if arg1 evals to string, array or document, either returns NULL.",
 }
 
 var mathDocs = functionDocs{

--- a/internal/expr/functions/testdata/builtin_functions.sql
+++ b/internal/expr/functions/testdata/builtin_functions.sql
@@ -33,4 +33,3 @@
 
 > typeof(NULL)
 'null'
-

--- a/sqltests/SELECT/len.sql
+++ b/sqltests/SELECT/len.sql
@@ -1,0 +1,155 @@
+-- setup:
+CREATE TABLE foo(
+  a TEXT,
+  b ARRAY,
+  c (
+      ...
+  )
+);
+INSERT INTO foo VALUES (
+  "hello",
+  [1, 2, 3, [4, 5]],
+  {
+    a: 1,
+    b: 2,
+    c: {
+      d: 3
+    }
+  }
+);
+
+-- test: text field
+SELECT len(a) FROM foo;
+/* result:
+{
+    "LEN(a)": 5
+}
+*/
+
+-- test: array field
+SELECT len(b) FROM foo;
+/* result:
+{
+    "LEN(b)": 4
+}
+*/
+
+-- test: document
+SELECT len(c) FROM foo;
+/* result:
+{
+    "LEN(c)": 3
+}
+*/
+
+-- test: subarray
+SELECT len(b[3]) FROM foo;
+/* result:
+{
+    "LEN(b[3])": 2
+}
+*/
+
+-- test: subdocument
+SELECT len(c.c) FROM foo;
+/* result:
+{
+    "LEN(c.c)": 1
+}
+*/
+
+-- test: text expr
+SELECT len("hello, world!");
+/* result:
+{
+  "LEN(\"hello, world!\")": 13
+}
+*/
+
+-- test: zero text expr
+SELECT len('');
+/* result:
+{
+  "LEN(\"\")": 0
+}
+*/
+
+-- test: array expr
+SELECT len([1, 2, 3, 4, 5]);
+/* result:
+{
+  "LEN([1, 2, 3, 4, 5])": 5
+}
+*/
+
+-- test: empty array expr
+SELECT len([]);
+/* result:
+{
+  "LEN([])": 0
+}
+*/
+
+-- test: mixed type array expr
+SELECT len([1, 2, 3, [1, 2, 3]]);
+/* result:
+{
+  "LEN([1, 2, 3, [1, 2, 3]])": 4
+}
+*/
+
+-- test: document expr
+SELECT len({'a': 1, 'b': 2, 'c': 3});
+/* result:
+{
+  "LEN({a: 1, b: 2, c: 3})": 3
+}
+*/
+
+-- test: empty document expr
+SELECT len({});
+/* result:
+{
+  "LEN({})": 0
+}
+*/
+
+-- test: integer expr
+SELECT len(10);
+/* result:
+{
+  "LEN(10)": NULL
+}
+*/
+
+-- test: float expr
+SELECT len(1.0);
+/* result:
+{
+  "LEN(1.0)": NULL
+}
+*/
+
+-- test: NULL expr
+SELECT len(NULL);
+/* result:
+{
+  "LEN(NULL)": NULL
+}
+*/
+
+-- test: NULL expr
+SELECT len(NULL);
+/* result:
+{
+  "LEN(NULL)": NULL
+}
+*/
+
+-- test: blob expr
+SELECT len('\x323232') as l;
+/* result:
+{
+  "l": NULL
+}
+*/


### PR DESCRIPTION
Fixes #474

I have few concerns about this PR:

* @asdine provided examples of using LEN with columns in tables. But this PR doesn't contain such tests, because tests will be required outside of `expr` package (or import of another parser will be needed). Anyway, I don't see anything bad in such test, but I don't known codebase well enough to decide is it worth it.
* Maybe error message can be improved.
* LEN function is quite expensive for ARRAY and DOCUMENT because it need to loop over elements. Probably this can be problem, but out of scope of  the mentioned issue and this PR.