### PR TITLE
Add forgotten import in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import (
 
     "github.com/genjidb/genji"
     "github.com/genjidb/genji/document"
+    "github.com/genjidb/genji/types"
 )
 
 func main() {


### PR DESCRIPTION
Add forgotten import in example

	"github.com/genjidb/genji/types"
