### PR TITLE
StructScan check interface parameter is a pointer to a struct

### DIFF
--- a/document/scan.go
+++ b/document/scan.go
@@ -52,6 +52,10 @@ func StructScan(d types.Document, t interface{}) error {
 		return errors.New("target must be pointer to a valid Go type")
 	}
 
+	if ref.Elem().Kind() != reflect.Struct {
+		return errors.New("target must be pointer to a struct")
+	}
+
 	if ref.IsNil() {
 		ref.Set(reflect.New(ref.Type().Elem()))
 	}

--- a/document/scan_test.go
+++ b/document/scan_test.go
@@ -292,6 +292,13 @@ func TestScan(t *testing.T) {
 		assert.NoError(t, err)
 		require.Equal(t, &foo{A: &bar{B: 10}}, &f)
 	})
+
+	t.Run("Pointer not to struct", func(t *testing.T) {
+		var b int
+		d := document.NewFieldBuffer().Add("a", types.NewIntegerValue(10))
+		err := document.StructScan(d, &b)
+		assert.Error(t, err)
+	})
 }
 
 type documentScanner struct {


### PR DESCRIPTION
Added check that an interface parameter is a pointer to a structure in StructScan.

Refers #453