### PR TITLE
fix: deep copy strings during scan

### DIFF
--- a/document/scan.go
+++ b/document/scan.go
@@ -275,7 +275,11 @@ func scanValue(v types.Value, ref reflect.Value) error {
 		if err != nil {
 			return err
 		}
-		ref.SetString(string(types.As[string](v)))
+		// copy the string to avoid
+		// keeping a reference to the underlying buffer
+		// which could be reused
+		cp := strings.Clone(types.As[string](v))
+		ref.SetString(cp)
 		return nil
 	case reflect.Bool:
 		v, err := CastAsBool(v)


### PR DESCRIPTION
When decoding a document from the disk, fields of type TEXT are not copied on purpose to avoid doing unnecessary copies.
However, when the data reaches the upper layers, usually when it's about to get scanned (i.e. document.Scan, document.StructScan), strings must always get deep cloned before being returned to the user.

Fixes #497 