### PR TITLE
Add coalesce function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ profile.*
 # Builds
 cmd/genji/genji
 
-# VS Code config
+# IDE config
 .vscode/
+.idea/
 
 # gopls log
 gopls.log

--- a/cmd/genji/doc/functions.go
+++ b/cmd/genji/doc/functions.go
@@ -8,14 +8,15 @@ var packageDocs = map[string]functionDocs{
 }
 
 var builtinDocs = functionDocs{
-	"pk":     "The pk() function returns the primary key for the current document",
-	"count":  "Returns a count of the number of times that arg1 is not NULL in a group. The count(*) function (with no arguments) returns the total number of rows in the group.",
-	"min":    "Returns the minimum value of the arg1 expression in a group.",
-	"max":    "Returns the maximum value of the arg1 expressein in a group.",
-	"sum":    "The sum function returns the sum of all values taken by the arg1 expression in a group.",
-	"avg":    "The avg function returns the average of all values taken by the arg1 expression in a group.",
-	"typeof": "The typeof function returns the type of arg1.",
-	"len":    "Then len function returns length of the arg1 expression if arg1 evals to string, array or document, either returns NULL.",
+	"pk":       "The pk() function returns the primary key for the current document",
+	"count":    "Returns a count of the number of times that arg1 is not NULL in a group. The count(*) function (with no arguments) returns the total number of rows in the group.",
+	"min":      "Returns the minimum value of the arg1 expression in a group.",
+	"max":      "Returns the maximum value of the arg1 expressein in a group.",
+	"sum":      "The sum function returns the sum of all values taken by the arg1 expression in a group.",
+	"avg":      "The avg function returns the average of all values taken by the arg1 expression in a group.",
+	"typeof":   "The typeof function returns the type of arg1.",
+	"len":      "The len function returns length of the arg1 expression if arg1 evals to string, array or document, either returns NULL.",
+	"coalesce": "The coalesce function returns the first non-null argument. NULL is returned if all arguments are null.",
 }
 
 var mathDocs = functionDocs{

--- a/cmd/genji/doc/functions.go
+++ b/cmd/genji/doc/functions.go
@@ -4,8 +4,8 @@ type functionDocs map[string]string
 
 var packageDocs = map[string]functionDocs{
 	"strings": stringsDocs,
-	"math": mathDocs,
-	"":     builtinDocs,
+	"math":    mathDocs,
+	"":        builtinDocs,
 }
 
 var builtinDocs = functionDocs{
@@ -32,9 +32,9 @@ var mathDocs = functionDocs{
 }
 
 var stringsDocs = functionDocs{
-	"lower":  "The lower function returns arg1 to lower-case if arg1 evals to string",
-	"upper":  "The upper function returns arg1 to upper-case if arg1 evals to string",
-	"trim":   "The trim function returns arg1 with leading and trailing characters removed. space by default or arg2",
-	"ltrim":   "The ltrim function returns arg1 with leading characters removed. space by default or arg2",
-	"rtrim":   "The rtrim function returns arg1 with trailing characters removed. space by default or arg2",
+	"lower": "The lower function returns arg1 to lower-case if arg1 evals to string",
+	"upper": "The upper function returns arg1 to upper-case if arg1 evals to string",
+	"trim":  "The trim function returns arg1 with leading and trailing characters removed. space by default or arg2",
+	"ltrim": "The ltrim function returns arg1 with leading characters removed. space by default or arg2",
+	"rtrim": "The rtrim function returns arg1 with trailing characters removed. space by default or arg2",
 }

--- a/internal/expr/functions/builtins.go
+++ b/internal/expr/functions/builtins.go
@@ -71,7 +71,6 @@ var builtinFunctions = Definitions{
 		name:  "coalesce",
 		arity: UNLIMITED,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
-			// FIXME: does it need a slice of expression
 			return &Coalesce{Exprs: args}, nil
 		},
 	},
@@ -731,8 +730,8 @@ type Coalesce struct {
 }
 
 func (c *Coalesce) Eval(e *environment.Environment) (types.Value, error) {
-	for _, expr := range c.Exprs {
-		v, err := expr.Eval(e)
+	for _, exp := range c.Exprs {
+		v, err := exp.Eval(e)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/expr/functions/builtins.go
+++ b/internal/expr/functions/builtins.go
@@ -72,7 +72,7 @@ var builtinFunctions = Definitions{
 		arity: UNLIMITED,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			// FIXME: does it need a slice of expression
-			return &Coalesce{Expr: args[0]}, nil
+			return &Coalesce{Exprs: args}, nil
 		},
 	},
 }
@@ -727,20 +727,26 @@ func (s *Len) String() string {
 }
 
 type Coalesce struct {
-	Expr expr.Expr
+	Exprs []expr.Expr
 }
 
 func (c *Coalesce) Eval(e *environment.Environment) (types.Value, error) {
-	//TODO implement me
-	panic("implement eval")
+	for _, expr := range c.Exprs {
+		v, err := expr.Eval(e)
+		if err != nil {
+			return nil, err
+		}
+		if v.Type() != types.NullValue {
+			return v, nil
+		}
+	}
+	return nil, nil
 }
 
 func (c *Coalesce) String() string {
-	//TODO implement me
-	panic("implement string")
+	return fmt.Sprintf("COALESCE(%v)", c.Exprs)
 }
 
 func (c *Coalesce) Params() []expr.Expr {
-	//TODO implement me
-	panic("implement params")
+	return c.Exprs
 }

--- a/internal/expr/functions/builtins.go
+++ b/internal/expr/functions/builtins.go
@@ -67,6 +67,14 @@ var builtinFunctions = Definitions{
 			return &Len{Expr: args[0]}, nil
 		},
 	},
+	"coalesce": &definition{
+		name:  "coalesce",
+		arity: UNLIMITED,
+		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
+			// FIXME: does it need a slice of expression
+			return &Coalesce{Expr: args[0]}, nil
+		},
+	},
 }
 
 // BuiltinDefinitions returns a map of builtin functions.
@@ -716,4 +724,23 @@ func (s *Len) Params() []expr.Expr { return []expr.Expr{s.Expr} }
 // String returns the literal representation of len.
 func (s *Len) String() string {
 	return fmt.Sprintf("LEN(%v)", s.Expr)
+}
+
+type Coalesce struct {
+	Expr expr.Expr
+}
+
+func (c *Coalesce) Eval(e *environment.Environment) (types.Value, error) {
+	//TODO implement me
+	panic("implement eval")
+}
+
+func (c *Coalesce) String() string {
+	//TODO implement me
+	panic("implement string")
+}
+
+func (c *Coalesce) Params() []expr.Expr {
+	//TODO implement me
+	panic("implement params")
 }

--- a/internal/expr/functions/builtins.go
+++ b/internal/expr/functions/builtins.go
@@ -69,7 +69,7 @@ var builtinFunctions = Definitions{
 	},
 	"coalesce": &definition{
 		name:  "coalesce",
-		arity: UNLIMITED,
+		arity: variadicArity,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Coalesce{Exprs: args}, nil
 		},

--- a/internal/expr/functions/definition.go
+++ b/internal/expr/functions/definition.go
@@ -60,10 +60,6 @@ func (fd *definition) Name() string {
 }
 
 func (fd *definition) Function(args ...expr.Expr) (expr.Function, error) {
-	//if fd.arity == -1 {
-	//	return fd.constructorFn(args...)
-	//}
-
 	if fd.arity != UNLIMITED && (len(args) != fd.arity) {
 		return nil, fmt.Errorf("%s() takes %d argument(s), not %d", fd.name, fd.arity, len(args))
 	}

--- a/internal/expr/functions/definition.go
+++ b/internal/expr/functions/definition.go
@@ -7,8 +7,8 @@ import (
 	"github.com/genjidb/genji/internal/expr"
 )
 
-// UNLIMITED represents an unlimited number of arguments.
-const UNLIMITED = -1
+// variadicArity represents an unlimited number of arguments.
+const variadicArity = -1
 
 // A Definition transforms a list of expressions into a Function.
 type Definition interface {
@@ -60,10 +60,10 @@ func (fd *definition) Name() string {
 }
 
 func (fd *definition) Function(args ...expr.Expr) (expr.Function, error) {
-	if fd.arity == UNLIMITED && len(args) == 0 {
+	if fd.arity == variadicArity && len(args) == 0 {
 		return nil, fmt.Errorf("%s() requires at least one argument", fd.name)
 	}
-	if fd.arity != UNLIMITED && (len(args) != fd.arity) {
+	if fd.arity != variadicArity && (len(args) != fd.arity) {
 		return nil, fmt.Errorf("%s() takes %d argument(s), not %d", fd.name, fd.arity, len(args))
 	}
 	return fd.constructorFn(args...)

--- a/internal/expr/functions/definition.go
+++ b/internal/expr/functions/definition.go
@@ -7,6 +7,9 @@ import (
 	"github.com/genjidb/genji/internal/expr"
 )
 
+// UNLIMITED represents an unlimited number of arguments.
+const UNLIMITED = -1
+
 // A Definition transforms a list of expressions into a Function.
 type Definition interface {
 	Name() string
@@ -56,7 +59,7 @@ func (fd *definition) Name() string {
 }
 
 func (fd *definition) Function(args ...expr.Expr) (expr.Function, error) {
-	if len(args) != fd.arity {
+	if fd.arity != UNLIMITED && (len(args) != fd.arity) {
 		return nil, fmt.Errorf("%s() takes %d argument(s), not %d", fd.name, fd.arity, len(args))
 	}
 	return fd.constructorFn(args...)

--- a/internal/expr/functions/definition.go
+++ b/internal/expr/functions/definition.go
@@ -60,6 +60,9 @@ func (fd *definition) Name() string {
 }
 
 func (fd *definition) Function(args ...expr.Expr) (expr.Function, error) {
+	if fd.arity == UNLIMITED && len(args) == 0 {
+		return nil, fmt.Errorf("%s() requires at least one argument", fd.name)
+	}
 	if fd.arity != UNLIMITED && (len(args) != fd.arity) {
 		return nil, fmt.Errorf("%s() takes %d argument(s), not %d", fd.name, fd.arity, len(args))
 	}

--- a/internal/expr/functions/strings.go
+++ b/internal/expr/functions/strings.go
@@ -26,21 +26,21 @@ var stringsFunctions = Definitions{
 	},
 	"trim": &definition{
 		name:  "trim",
-		arity: UNLIMITED,
+		arity: variadicArity,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Trim{Expr: args, TrimFunc: strings.Trim, Name: "TRIM"}, nil
 		},
 	},
 	"ltrim": &definition{
 		name:  "ltrim",
-		arity: UNLIMITED,
+		arity: variadicArity,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Trim{Expr: args, TrimFunc: strings.TrimLeft, Name: "LTRIM"}, nil
 		},
 	},
 	"rtrim": &definition{
 		name:  "rtrim",
-		arity: UNLIMITED,
+		arity: variadicArity,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Trim{Expr: args, TrimFunc: strings.TrimRight, Name: "RTRIM"}, nil
 		},

--- a/internal/expr/functions/strings.go
+++ b/internal/expr/functions/strings.go
@@ -26,21 +26,21 @@ var stringsFunctions = Definitions{
 	},
 	"trim": &definition{
 		name:  "trim",
-		arity: -1,
+		arity: UNLIMITED,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Trim{Expr: args, TrimFunc: strings.Trim, Name: "TRIM"}, nil
 		},
 	},
 	"ltrim": &definition{
 		name:  "ltrim",
-		arity: -1,
+		arity: UNLIMITED,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Trim{Expr: args, TrimFunc: strings.TrimLeft, Name: "LTRIM"}, nil
 		},
 	},
 	"rtrim": &definition{
 		name:  "rtrim",
-		arity: -1,
+		arity: UNLIMITED,
 		constructorFn: func(args ...expr.Expr) (expr.Function, error) {
 			return &Trim{Expr: args, TrimFunc: strings.TrimRight, Name: "RTRIM"}, nil
 		},

--- a/internal/sql/parser/parser.go
+++ b/internal/sql/parser/parser.go
@@ -268,9 +268,6 @@ func (p *Parser) parseTokens(tokens ...scanner.Token) error {
 // present, it unscans and return false. If the first is present, all the others
 // must be parsed otherwise an error is returned.
 func (p *Parser) parseOptional(tokens ...scanner.Token) (bool, error) {
-	if len(tokens) == 0 {
-		return false, nil
-	}
 	// Parse optional first token
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != tokens[0] {
 		p.Unscan()

--- a/internal/sql/parser/parser.go
+++ b/internal/sql/parser/parser.go
@@ -232,6 +232,7 @@ func (p *Parser) parseTokens(tokens ...scanner.Token) error {
 // present, it unscans and return false. If the first is present, all the others
 // must be parsed otherwise an error is returned.
 func (p *Parser) parseOptional(tokens ...scanner.Token) (bool, error) {
+	// FIXME: potential panic here
 	// Parse optional first token
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != tokens[0] {
 		p.Unscan()

--- a/internal/sql/parser/parser.go
+++ b/internal/sql/parser/parser.go
@@ -268,7 +268,9 @@ func (p *Parser) parseTokens(tokens ...scanner.Token) error {
 // present, it unscans and return false. If the first is present, all the others
 // must be parsed otherwise an error is returned.
 func (p *Parser) parseOptional(tokens ...scanner.Token) (bool, error) {
-	// FIXME: potential panic here
+	if len(tokens) == 0 {
+		return false, nil
+	}
 	// Parse optional first token
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok != tokens[0] {
 		p.Unscan()

--- a/internal/stream/operator.go
+++ b/internal/stream/operator.go
@@ -11,7 +11,7 @@ var ErrInvalidResult = errors.New("expression must evaluate to a document")
 
 // An Operator is used to modify a stream.
 // It takes an environment containing the current value as well as any other metadata
-// created by other operatorsand returns a new environment which will be passed to the next operator.
+// created by other operators and returns a new environment which will be passed to the next operator.
 // If it returns a nil environment, the env will be ignored.
 // If it returns an error, the stream will be interrupted and that error will bubble up
 // and returned by this function, unless that error is ErrStreamClosed, in which case

--- a/sqltests/expr/coalesce.sql
+++ b/sqltests/expr/coalesce.sql
@@ -1,0 +1,19 @@
+-- test: simple case
+> COALESCE(1,2,3)
+1
+
+-- test: with null
+> COALESCE(null,2,3)
+2
+
+-- test: with different values type
+> COALESCE('hey',2,3)
+'hey'
+
+-- test: with more than one null value with integer
+> COALESCE(null, null, null,3)
+3
+
+-- test: with more than one null value with text
+> COALESCE(null, null, null, 'hey')
+'hey'


### PR DESCRIPTION
This PR fixes #509 by adding support to `COALESCE` method.
Unlike PosgreSQL, our implementation doesn't fail if the arguments aren't of the same type.
However, an error is returned if there is no argument at all.
